### PR TITLE
[JJ] Add in user profiles retrieval endpoint

### DIFF
--- a/app/classes/user_profile_serializer.rb
+++ b/app/classes/user_profile_serializer.rb
@@ -1,4 +1,4 @@
-class ParentUserProfileSerializer
+class UserProfileSerializer
   def self.serialize(user)
     new(user).serialize
   end
@@ -11,7 +11,7 @@ class ParentUserProfileSerializer
   def serialize
     {
       profile: {
-        emai: user.email,
+        email: user.email,
         user_name: user.user_name,
         slug: user.slug,
         first_name: user.first_name,
@@ -20,12 +20,15 @@ class ParentUserProfileSerializer
         emergency_contact: user.emergency_contact,
         emergency_contact_phone_number: user.emergency_contact_phone_number,
         timezone: user.timezone,
+        slug: user.slug,
         parent: {
-          address1: parent.address1,
-          address2: parent.address2,
-          city: parent.city,
-          state: parent.state,
-          zip: parent.zip
+          address1: parent&.address1,
+          address2: parent&.address2,
+          city: parent&.city,
+          state: parent&.state,
+          zip: parent&.zip,
+          created_at: parent&.created_at,
+          updated_at: parent&.updated_at
         },
         teacher: {}
       }

--- a/app/controllers/api/v1/user_profile_changes_controller.rb
+++ b/app/controllers/api/v1/user_profile_changes_controller.rb
@@ -4,11 +4,6 @@ module Api
       before_action :authorize_access_request!
 
       swagger_controller :user_profile_changes, 'User Profile Changes Management'
-
-      def index
-        # TBI
-      end
-
       swagger_api :create do
         summary 'Creating (updating) user profiles'
         param :header, 'Authorization', :string, :required, 'Expired Acccess Token'
@@ -36,7 +31,7 @@ module Api
             profile_params: profile_update_params
           )
 
-          render json: ParentUserProfileSerializer.serialize(current_user.reload), status: :created
+          render json: UserProfileSerializer.serialize(current_user.reload), status: :created
         rescue UserProfileUpdater::MutationError => exception
           render json: { errors: { profile_mutation_error: exception.to_s } }, status: :internal_server_error
         end

--- a/app/controllers/api/v1/user_profiles_controller.rb
+++ b/app/controllers/api/v1/user_profiles_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V1
+    class UserProfilesController < ApplicationController
+      class ForbiddenAccessError < StandardError; end
+      before_action :authorize_access_request!
+
+      swagger_controller :user_profiles, 'User Profile Retrieval Management'
+      swagger_api :index do
+        summary 'Retrieve user specific profile info'
+        param :query, 'email', :string, required: true
+        response :forbidden
+        response :ok
+      end
+
+      def index
+        begin
+          raise ForbiddenAccessError.new('You\'re forbidden to access this user profile') if incompatible_user?
+          render json: UserProfileSerializer.serialize(current_user), status: :ok
+        rescue ForbiddenAccessError => exception
+          render json: { errors: { forbidden_to_retrieve_profile_error: exception.to_s } }, status: :forbidden
+        end
+      end
+
+      private
+
+      def profile_query_params
+        params.permit(:email)
+      end
+
+      def incompatible_user?
+        profile_query_params[:email] != current_user.email 
+      end
+    end
+  end
+end

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -1,5 +1,6 @@
 class Parent < ApplicationRecord
   belongs_to :user
+  has_many :students
 
   validates :user_id, presence: true, uniqueness: true
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,0 +1,5 @@
+class Student < ApplicationRecord
+  belongs_to :parent
+
+  validates :first_name, :last_name, :date_of_birth, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   include BCrypt
 
   has_one :parent
+  has_many :students, through: :parent
   validates :email, :password_hash, presence: true
 
   friendly_id :slug_builder, use: [:slugged, :finders, :history], sequence_separator: '-'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
       resources :authentications, only: [:create]
       resources :authentication_renewals, only: [:create]
       resources :sign_ups, only: [:create]
-      resources :user_profile_changes, only: [:create, :index]
+      resources :user_profiles, only: [:index]
+      resources :user_profile_changes, only: [:create]
     end
   end
 end

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -16,6 +16,10 @@
       "description": "Sign Ups Management"
     },
     {
+      "path": "/api/v1/user_profiles.{format}",
+      "description": "User Profile Retrieval Management"
+    },
+    {
       "path": "/api/v1/user_profile_changes.{format}",
       "description": "User Profile Changes Management"
     }

--- a/public/api/v1/api/v1/user_profiles.json
+++ b/public/api/v1/api/v1/user_profiles.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "user_profiles",
+  "apis": [
+    {
+      "path": "/api/v1/user_profiles.json",
+      "operations": [
+        {
+          "summary": "Retrieve user specific profile info",
+          "parameters": [
+            {
+              "paramType": "query",
+              "name": "email",
+              "type": "string",
+              "description": null,
+              "required": false
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 403,
+              "responseModel": null,
+              "message": "Forbidden"
+            }
+          ],
+          "nickname": "Api::V1::UserProfiles#index",
+          "method": "get"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/spec/requests/api/v1/user_profiles_spec.rb
+++ b/spec/requests/api/v1/user_profiles_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe Api::V1::UserProfilesController, type: :request do
+  include FakeAuthEstablishable
+
+  let!(:user) { create(:user, password: 'aeiiee12345!') }
+  let!(:parent) { create(:parent, user: user) }
+
+  let(:profile_populate_data) do
+    {
+      first_name: 'Hank',
+      last_name: 'Sonny',
+      user_name: 'Tempt',
+      phone_number: '616-116-1166',
+      emergency_contact: 'Tania Sonny',
+      emergency_contact_phone_number: '616-233-0033',
+      timezone: 'America/New_York',
+      address1: '305 3rd St',
+      address2: 'Apt E',
+      city: 'Salem',
+      state: 'VT',
+      zip: '09165'
+    }
+  end
+
+  before do
+    establish_valid_token!(user)
+    UserProfileUpdater.update!(user: user, profile_params: profile_populate_data)
+  end
+
+  it 'encounters forbidden access error' do
+    get '/api/v1/user_profiles', params: { email: 'someone@aeiou.edu' }, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+    expect(response.status).to eq 403
+    body = JSON.parse(response.body).with_indifferent_access
+
+    expect(body[:errors][:forbidden_to_retrieve_profile_error]).
+      to eq 'You\'re forbidden to access this user profile'
+  end
+
+  it 'retrieves back the user\'s associated profile info' do
+    get '/api/v1/user_profiles', params: { email: user.email }, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+    expect(response.status).to eq 200
+    body = JSON.parse(response.body).with_indifferent_access
+
+    expect(body[:profile][:email]).to eq user.email
+    expect(body[:profile][:first_name]).to eq 'Hank'
+    expect(body[:profile][:slug]).to eq 'tempt'
+    expect(body[:profile][:parent][:address2]).to eq 'Apt E'
+    expect(body[:profile][:parent][:zip]).to eq '09165'
+  end
+end


### PR DESCRIPTION
notes: Add in user profile retrieval endpoint

The return payload will have a `profile:` envelope. To detect, whether a user profile is `parent` or `teacher` based, make a check into `[:profile][:parent][:created_at]` or `[:profile][:teacher][:created_at]` to check the profile perspective. Note that in the long haul, a user profile, can have multiple perspective, for now we focus on parent user side

