### PR TITLE
[JJ] Setup configatron and ensure jwt uses configatron specified redis uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore redis dump file
+dump.rdb
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.5.3'
 
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bcrypt'
+gem 'configatron'
 gem 'friendly_id', '~> 5.2.4'
 gem 'jwt_sessions'
 gem 'pg', '>= 0.18', '< 2.0'
@@ -17,6 +18,7 @@ gem 'swagger-docs'
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'database_cleaner'
+  gem 'dotenv-rails', :require => 'dotenv/rails-now'
   gem 'hirb'
   gem 'pry'
   gem 'rspec-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     byebug (11.1.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
+    configatron (4.5.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -59,6 +60,10 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -201,7 +206,9 @@ DEPENDENCIES
   bcrypt
   bootsnap (>= 1.1.0)
   byebug
+  configatron
   database_cleaner
+  dotenv-rails
   factory_bot
   friendly_id (~> 5.2.4)
   hirb

--- a/config/configatron/defaults.rb
+++ b/config/configatron/defaults.rb
@@ -1,0 +1,1 @@
+configatron.redis_url = 'redis://localhost:6379'

--- a/config/configatron/development.rb
+++ b/config/configatron/development.rb
@@ -1,0 +1,4 @@
+# Override your default settings for the Development environment here.
+#
+# Example:
+#   configatron.file.storage = :local

--- a/config/configatron/production.rb
+++ b/config/configatron/production.rb
@@ -1,0 +1,1 @@
+configatron.redis_url = ENV['REDIS_URL']

--- a/config/configatron/staging.rb
+++ b/config/configatron/staging.rb
@@ -1,0 +1,1 @@
+configatron.redis_url = ENV['REDIS_URL']

--- a/config/configatron/test.rb
+++ b/config/configatron/test.rb
@@ -1,0 +1,4 @@
+# Override your default settings for the Test environment here.
+#
+# Example:
+#   configatron.file.storage = :local

--- a/config/initializers/configatron.rb
+++ b/config/initializers/configatron.rb
@@ -1,0 +1,2 @@
+require 'configatron'
+Configatron::Integrations::Rails.init

--- a/config/initializers/jwt_session.rb
+++ b/config/initializers/jwt_session.rb
@@ -1,3 +1,4 @@
+JWTSessions.token_store = :redis, { redis_url: configatron.redis_url }
 JWTSessions.access_exp_time = 10800
 JWTSessions.access_header  = "Authorization"
 JWTSessions.algorithm = "HS256"

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+$redis = Redis.new(url: configatron.redis_url)


### PR DESCRIPTION
notes: Setup configatron and ensure jwt uses configatron specified redis uri

This will ensure that heroku side can properly use the specific redis-to-go
