### PR TITLE
[JJ] Add in user password reset token gen endpoint and mailer

### DIFF
--- a/app/controllers/api/v1/password_reset_requests_controller.rb
+++ b/app/controllers/api/v1/password_reset_requests_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V1
+    class PasswordResetRequestsController < ApplicationController
+      def create
+        begin
+          user = User.find_by(email: user_email)
+          raise 'There is no matching user for the email you\'ve provided' if user.blank?
+
+          user.generate_password_reset_token!
+          AccessbilityMailer.request_for_password_reset(user).deliver_now
+
+          head :created
+        rescue => exception
+          render json: { errors: { password_reset_request_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def user_email
+        params.require(:reset_request).permit(:user_email) 
+      end
+    end
+  end
+end

--- a/app/mailers/accessibility_mailer.rb
+++ b/app/mailers/accessibility_mailer.rb
@@ -1,0 +1,19 @@
+class AccessbilityMailer < ApplicationMailer
+  def request_for_password_reset(user)
+    @user = user
+    @host = if Rails.env.development?
+      'http://localhost:9292'
+    elsif Rails.env.staging?
+      'https://staging.alphabetaacademy.org'
+    elsif Rails.env.production?
+      'https://www.alphabetaacademy.org'
+    end
+
+    mail(
+      to: user.email,
+      from: 'ABA <admin@alphabetaschool.org>',
+      subject: 'ABA Account Password Reset',
+      template_path: 'mailer/accessibility'
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,22 @@ class User < ApplicationRecord
     password == clear_password
   end
 
+  def generate_password_reset_token!
+    begin
+      self.password_reset_token = SecureRandom.urlsafe_base64
+    end while User.exists?(password_reset_token: self.password_reset_token)
+
+    self.password_reset_token_expires_at = 1.day.from_now
+    save!
+  end
+
+  def clear_password_reset_token!
+    self.reset_password_token = nil
+    self.reset_password_token_expires_at = nil
+
+    save!
+  end
+
   private
 
   def slug_builder

--- a/app/views/mailer/accessibility/request_for_password_reset.html.erb
+++ b/app/views/mailer/accessibility/request_for_password_reset.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <p>Hi <%= @user.last_name %>,</p>
+    
+    <p>You have requested to reset your password.
+    Please follow this link: <%= "#{@host}/password_resets/#{@user.   password_reset_token}" %>
+    </p>
+    
+    <p>This reset password URL is only valid for the next 24 hours.</p    >
+    
+    <p>------------------------------</p>
+    <p>ABA Admin</p>
+    <p><a href="www.alphabetaacademy.org">www.alphabetaacademy.org</a>    </p>
+    <p><%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %></p>
+    <p>------------------------------</p>
+  </body>
+</html>

--- a/app/views/mailer/accessibility/request_for_password_reset.text.erb
+++ b/app/views/mailer/accessibility/request_for_password_reset.text.erb
@@ -1,0 +1,10 @@
+Hi <%= @user.last_name %>,
+
+You have requested to reset your password.
+Please follow this link: <%= "#{@host}/password_resets/#{@user.password_reset_token}" %>
+
+This reset password URL is only valid for the next 24 hours.
+
+ABA Admin
+www.alphabetaacademy.org
+<%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %>

--- a/app/views/mailer/registration/aba_admin_registration_notification.html.erb
+++ b/app/views/mailer/registration/aba_admin_registration_notification.html.erb
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
   </head>
   <body>
-    <p>Dear ABLS Admin,</p>
+    <p>Dear ABA Admin,</p>
     
     <p>A new registration has just came through. Below are the detailed info.</p>
     <br/>
@@ -19,8 +19,8 @@
     </table>
     
     <p>------------------------------</p>
-    <p>ABLS Admin</p>
-    <p><a href="www.alphabetaschool.org">www.alphabetaschool.org</a></p>
+    <p>ABA Admin</p>
+    <p><a href="www.alphabetaacademy.org">www.alphabetaacademy.org</a></p>
     <p><%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %></p>
     <p>------------------------------</p>
   </body>

--- a/app/views/mailer/registration/aba_admin_registration_notification.text.erb
+++ b/app/views/mailer/registration/aba_admin_registration_notification.text.erb
@@ -1,4 +1,4 @@
-Dear ABLS Admin,
+Dear ABA Admin,
 
 A new registration has just came through. Below are the detailed info.
 
@@ -11,7 +11,7 @@ Studied Level: <%= @studied_level %>
 Registered on: <%= @registered_on %>
 
 ---------------
-ABLS Internal
-www.alphabetaschool.org
+ABA Internal
+www.alphabetaacademy.org
 <%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %>
 ---------------

--- a/app/views/mailer/registration/registration_confirmation.html.erb
+++ b/app/views/mailer/registration/registration_confirmation.html.erb
@@ -19,8 +19,8 @@
     <p>Thanks,</p>
     
     <p>------------------------------</p>
-    <p>ABLS Admin</p>
-    <p><a href="www.alphabetaschool.org">www.alphabetaschool.org</a></p>
+    <p>ABA Admin</p>
+    <p><a href="www.alphabetaacademy.org">www.alphabetaacademy.org</a></p>
     <p><%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %></p>
     <p>------------------------------</p>
   </body>

--- a/app/views/mailer/registration/registration_confirmation.text.erb
+++ b/app/views/mailer/registration/registration_confirmation.text.erb
@@ -17,7 +17,7 @@ Below are some quick notes and tips:
 Thanks,
 
 ------------------------------
-ABLS Admin
-www.alphabetaschool.org
+ABA Admin
+www.alphabetaacademy.org
 <%= Time.now.strftime("%m-%d-%Y %H:%M:%S") %>
 ------------------------------

--- a/app/views/mailer/registration/test.html.erb
+++ b/app/views/mailer/registration/test.html.erb
@@ -1,3 +1,3 @@
 <p>
-    Hello world, This is me, of course!
+  Hello world, This is me, of course!
 </p>

--- a/config/configatron/production.rb
+++ b/config/configatron/production.rb
@@ -1,8 +1,8 @@
 configatron.redis_url = ENV['REDIS_URL']
 
 configatron.mailer.smtp_settings.port = 587
-configatron.mailer.smtp_settings.address = 'smtp.mailgun.org'
-configatron.mailer.smtp_settings.user_name = ENV['MAILGUN_SMTP_LOGIN']
-configatron.mailer.smtp_settings.password = ENV['MAILGUN_SMTP_PASSWORD']
+configatron.mailer.smtp_settings.address = 'smtp.sendgrid.net'
+configatron.mailer.smtp_settings.user_name = ENV['SENDGRID_USERNAME']
+configatron.mailer.smtp_settings.password = ENV['SENDGRID_PASSWORD']
 configatron.mailer.smtp_settings.delivery_method = :smtp
 configatron.mailer.smtp_settings.domain = 'alphabetaacademy.org'

--- a/config/configatron/staging.rb
+++ b/config/configatron/staging.rb
@@ -1,8 +1,8 @@
 configatron.redis_url = ENV['REDIS_URL']
 
 configatron.mailer.smtp_settings.port = 587
-configatron.mailer.smtp_settings.address = 'smtp.mailgun.org'
-configatron.mailer.smtp_settings.user_name = ENV['MAILGUN_SMTP_LOGIN']
-configatron.mailer.smtp_settings.password = ENV['MAILGUN_SMTP_PASSWORD']
+configatron.mailer.smtp_settings.address = 'smtp.sendgrid.net'
+configatron.mailer.smtp_settings.user_name = ENV['SENDGRID_USERNAME']
+configatron.mailer.smtp_settings.password = ENV['SENDGRID_PASSWORD']
 configatron.mailer.smtp_settings.delivery_method = :smtp
 configatron.mailer.smtp_settings.domain = 'staging.alphabetaacademy.org'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       resources :courses, only: [:index]
       resources :class_sessions, only: [:show]
       resources :family_members, only: [:create, :index, :destroy]
+      resources :password_reset_requests, only: [:create]
       resources :registrations, only: [:create, :index] do
         member do
           get 'class_sessions'

--- a/db/migrate/20200802231358_add_reset_password_fields_to_users.rb
+++ b/db/migrate/20200802231358_add_reset_password_fields_to_users.rb
@@ -1,0 +1,7 @@
+class AddResetPasswordFieldsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_reset_token, :string
+    add_column :users, :password_reset_token_expires_at, :datetime
+    add_index :users, :password_reset_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_06_203545) do
+ActiveRecord::Schema.define(version: 2020_08_02_231358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,7 +150,10 @@ ActiveRecord::Schema.define(version: 2020_07_06_203545) do
     t.datetime "updated_at", null: false
     t.text "password_hash", null: false
     t.string "slug"
+    t.string "password_reset_token"
+    t.datetime "password_reset_token_expires_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["password_reset_token"], name: "index_users_on_password_reset_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
   end
 


### PR DESCRIPTION
notes: Generate user reset pass token and an endpoint, by user email to request for it and subsequently getting an email

Also as a side, switch back to sendgrid for email sending, since prod app is now resolved to have sendgrid re-added, successfully in heroku.