### PR TITLE
[JJ] Fix class session show endpt, need to have associated material be serialized

### DIFF
--- a/app/models/class_session.rb
+++ b/app/models/class_session.rb
@@ -14,8 +14,8 @@ class ClassSession < ApplicationRecord
       id: id,
       status: status,
       effective_for: effective_for,
-      student_materials: student_specific_materials,
-      teacher_materials: teacher_specific_materials,
+      student_materials: student_specific_materials.map(&:as_serialized_hash),
+      teacher_materials: teacher_specific_materials.map(&:as_serialized_hash),
       individual_session_starts_at: individual_session_starts_at,
       created_at: created_at,
       updated_at: updated_at

--- a/spec/requests/api/v1/class_sessions_spec.rb
+++ b/spec/requests/api/v1/class_sessions_spec.rb
@@ -50,6 +50,8 @@ describe Api::V1::ClassSessionsController do
       file_path,
       file_type
     )
+
+    allow_any_instance_of(ClassSessionMaterial).to receive(:material_access_url).and_return('http://s3.aws/example-material')
   end
 
   describe '#show' do
@@ -70,6 +72,7 @@ describe Api::V1::ClassSessionsController do
       expect(body['class_session']['student_materials'].size).to eq 1
       expect(body['class_session']['student_materials'].first['mime_type']).to eq 'image/jpg'
       expect(body['class_session']['student_materials'].first['name']).to eq 'image1.jpg'
+      expect(body['class_session']['student_materials'].first['material_access_url']).to eq 'http://s3.aws/example-material'
     end
   end
 end


### PR DESCRIPTION
notes: previously, it was just getting the AR data serialized by default, need to actually call the `#as_serialized_hash` method to ensure, custom attributes such as `material_access_url` is also returned.
