### PR TITLE
[JJ] Add in endpoints to verify and actually updates user passwords

### DIFF
--- a/app/controllers/api/v1/class_sessions_controller.rb
+++ b/app/controllers/api/v1/class_sessions_controller.rb
@@ -3,6 +3,16 @@ module Api
     class ClassSessionsController < ApplicationController
       before_action :authorize_access_request!
 
+      swagger_controller :class_sessions, 'Class sessions management'
+
+      swagger_api :show do
+        summary 'Returns a specific class session data'
+        param :query, 'id', :integer, :required, 'unique identifier of the class session'
+        response :unauthorized
+        response :internal_server_error
+        response :ok
+      end
+
       def show
         begin
           raise 'Unable to retrieve the specific class session, you do not have access to it' if unauthorized_access?

--- a/app/controllers/api/v1/password_resets_controller.rb
+++ b/app/controllers/api/v1/password_resets_controller.rb
@@ -1,0 +1,68 @@
+module Api
+  module V1
+    class PasswordResetsController < ApplicationController
+      swagger_controller :password_resets, 'Password resetting management'
+
+      swagger_api :edit do
+        summary 'Verifies whether the reset token is valid'
+        param :query, 'reset_token', :string, :required, 'System generated reset password token'
+        response :unauthorized
+        response :internal_server_error
+        response :ok
+      end
+
+      def edit
+        begin
+          raise 'Unable to find a user with the specified reset token' if user.blank?
+          raise 'Specified reset token has expired' if user.password_reset_token_expires_at < Time.zone.now
+        
+          head :ok
+        rescue => exception
+          render json: { errors: { password_reset_token_invalid_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      swagger_api :update do
+        summary 'Updates a user\'s password to a new one'
+        param :query, 'reset_token', :string, :required, 'System generated reset password token'
+        param :form, 'password_reset[password]', :string, :required, 'New password'
+        param :form, 'password_reset[password_confirmation]', :string, :required, 'New password confirmation'
+        response :unauthorized
+        response :internal_server_error
+        response :ok
+      end
+
+      def update
+        begin
+          raise 'Unable to find the user to update the new password' if user.blank?
+          raise 'You have elapsed the time to update your password, please request a new password reset' if user.password_reset_token_expires_at < Time.zone.now
+          raise 'Password and password confirmation are not matching, please try again' if password_reset_params[:password] != password_reset_params[:password_confirmation]
+
+          ActiveRecord::Base.transaction do
+            user.password = password_reset_params[:password]
+            user.save!
+            user.clear_password_reset_token!
+          end
+
+          head :ok
+        rescue => exception
+          render json: { errors: { password_update_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def reset_token_param
+        params.permit(:reset_token)
+      end
+
+      def password_reset_params
+        params.require(:password_reset).permit(:password, :password_confirmation) 
+      end
+
+      def user
+        @user ||= User.where(password_reset_token: reset_token_param[:reset_token]).first
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,8 +31,8 @@ class User < ApplicationRecord
   end
 
   def clear_password_reset_token!
-    self.reset_password_token = nil
-    self.reset_password_token_expires_at = nil
+    self.password_reset_token = nil
+    self.password_reset_token_expires_at = nil
 
     save!
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       resources :class_sessions, only: [:show]
       resources :family_members, only: [:create, :index, :destroy]
       resources :password_reset_requests, only: [:create]
+      resources :password_resets, param: :reset_token, constraints: { reset_token: /[\-\d\w]+/ }, only: [:edit, :update]
       resources :registrations, only: [:create, :index] do
         member do
           get 'class_sessions'

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -16,8 +16,16 @@
       "description": "Courses Management"
     },
     {
+      "path": "/api/v1/class_sessions.{format}",
+      "description": "Class sessions management"
+    },
+    {
       "path": "/api/v1/family_members.{format}",
       "description": "Family members management"
+    },
+    {
+      "path": "/api/v1/password_resets.{format}",
+      "description": "Password resetting management"
     },
     {
       "path": "/api/v1/registrations.{format}",

--- a/public/api/v1/api/v1/class_sessions.json
+++ b/public/api/v1/api/v1/class_sessions.json
@@ -1,0 +1,45 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "class_sessions",
+  "apis": [
+    {
+      "path": "/api/v1/class_sessions/{id}.json",
+      "operations": [
+        {
+          "summary": "Returns a specific class session data",
+          "parameters": [
+            {
+              "paramType": "query",
+              "name": "id",
+              "type": "integer",
+              "description": "unique identifier of the class session",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::ClassSessions#show",
+          "method": "get"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/public/api/v1/api/v1/password_resets.json
+++ b/public/api/v1/api/v1/password_resets.json
@@ -1,0 +1,95 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "password_resets",
+  "apis": [
+    {
+      "path": "/api/v1/password_resets/{reset_token}/edit.json",
+      "operations": [
+        {
+          "summary": "Verifies whether the reset token is valid",
+          "parameters": [
+            {
+              "paramType": "query",
+              "name": "reset_token",
+              "type": "string",
+              "description": "System generated reset password token",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::PasswordResets#edit",
+          "method": "get"
+        }
+      ]
+    },
+    {
+      "path": "/api/v1/password_resets/{reset_token}.json",
+      "operations": [
+        {
+          "summary": "Updates a user's password to a new one",
+          "parameters": [
+            {
+              "paramType": "query",
+              "name": "reset_token",
+              "type": "string",
+              "description": "System generated reset password token",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "password_reset[password]",
+              "type": "string",
+              "description": "New password",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "password_reset[password_confirmation]",
+              "type": "string",
+              "description": "New password confirmation",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::PasswordResets#update",
+          "method": "patch"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/spec/requests/api/v1/password_resets_spec.rb
+++ b/spec/requests/api/v1/password_resets_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Api::V1::PasswordResetsController, type: :request do
+  let(:user) { create(:user, password: 'abcde12345!') }
+
+  before do
+    user.generate_password_reset_token!
+  end
+
+  describe '#edit' do
+    it 'raises an exception when an invalid, unrecognized reset token' do
+      token = user.password_reset_token + '-007'
+      get "/api/v1/password_resets/#{token}/edit"
+      expect(response.status).to eq 500
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body['errors']['password_reset_token_invalid_error']).
+        to eq 'Unable to find a user with the specified reset token'
+    end
+
+    it 'raises an exception when a reset token has expired' do
+      user.update!(password_reset_token_expires_at: 2.days.ago)
+      get "/api/v1/password_resets/#{user.password_reset_token}/edit"
+      expect(response.status).to eq 500
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body['errors']['password_reset_token_invalid_error']).
+        to eq 'Specified reset token has expired'
+    end
+
+    it 'successfully verifies the password token, with a 200 response status' do
+      get "/api/v1/password_resets/#{user.password_reset_token}/edit"
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe '#update' do
+    it 'raises password and password confirmation mis-matched exception' do
+      put "/api/v1/password_resets/#{user.password_reset_token}", params: { password_reset: { password: 'abcde67890!', password_confirmation: 'abcde67891!' } }
+      expect(response.status).to eq 500
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body['errors']['password_update_error']).
+        to eq 'Password and password confirmation are not matching, please try again'
+    end
+
+    it 'successfully updates the user password and clears the reset token' do
+      put "/api/v1/password_resets/#{user.password_reset_token}", params: { password_reset: { password: 'abcde67890!', password_confirmation: 'abcde67890!' } }
+      expect(response.status).to eq 200
+      reloaded_user = User.find(user.id)
+
+      result = (reloaded_user.password == 'abcde67890!')
+      expect(result).to be_truthy
+      expect(reloaded_user.password_reset_token).to be_nil
+      expect(reloaded_user.password_reset_token_expires_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
notes: Add in:

- `/api/v1/password_resets/:reset_token/edit`
- `/api/v1/password_resets/:reset_token/`

two endpoints

The former is used to verify if the token is able to identify a user and whether the token is still timely valid

The second one, uses a request body of `{ password_reset: { password: ' ... ', password_confirmation: ' ... ' } }` to actually update the targeted user's password to a new one.