### PR TITLE
[JJ] Namespace auth token, during password reset, clear off old auth session

### DIFF
--- a/app/controllers/api/v1/password_reset_requests_controller.rb
+++ b/app/controllers/api/v1/password_reset_requests_controller.rb
@@ -1,9 +1,18 @@
 module Api
   module V1
     class PasswordResetRequestsController < ApplicationController
+      swagger_controller :password_resets, 'Password reset request management'
+
+      swagger_api :create do
+        summary 'Request to reset password for a user'
+        param :form, 'reset_request[user_email]', :string, :required, 'Requesting reset user\'s email'
+        response :internal_server_error
+        response :created
+      end
+
       def create
         begin
-          user = User.find_by(email: user_email)
+          user = User.find_by(email: user_email_param[:user_email])
           raise 'There is no matching user for the email you\'ve provided' if user.blank?
 
           user.generate_password_reset_token!
@@ -17,7 +26,7 @@ module Api
 
       private
 
-      def user_email
+      def user_email_param
         params.require(:reset_request).permit(:user_email) 
       end
     end

--- a/app/controllers/api/v1/password_resets_controller.rb
+++ b/app/controllers/api/v1/password_resets_controller.rb
@@ -43,6 +43,7 @@ module Api
             user.save!
             user.clear_password_reset_token!
           end
+          JWTSessions::Session.new(namespace: "user_id_#{user.id}").flush_namespaced
 
           head :ok
         rescue => exception

--- a/app/controllers/concerns/session_establishable.rb
+++ b/app/controllers/concerns/session_establishable.rb
@@ -3,7 +3,11 @@ module Concerns
     def obtain_session_and_recognize_errors!
       if user_permitted_for_session_access?
         payload = { user_id: user.id }
-        session = JWTSessions::Session.new(payload: payload, refresh_by_access_allowed: true)
+        session = JWTSessions::Session.new(
+          payload: payload,
+          refresh_by_access_allowed: true,
+          namespace: "user_id_#{user.id}"
+        )
         render json: session.login.slice(:access, :access_expires_at), status: :created
       else
         yield

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -24,6 +24,10 @@
       "description": "Family members management"
     },
     {
+      "path": "/api/v1/password_reset_requests.{format}",
+      "description": "Password reset request management"
+    },
+    {
       "path": "/api/v1/password_resets.{format}",
       "description": "Password resetting management"
     },

--- a/public/api/v1/api/v1/password_reset_requests.json
+++ b/public/api/v1/api/v1/password_reset_requests.json
@@ -1,0 +1,40 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "password_reset_requests",
+  "apis": [
+    {
+      "path": "/api/v1/password_reset_requests.json",
+      "operations": [
+        {
+          "summary": "Request to reset password for a user",
+          "parameters": [
+            {
+              "paramType": "form",
+              "name": "reset_request[user_email]",
+              "type": "string",
+              "description": "Requesting reset user's email",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 201,
+              "responseModel": null,
+              "message": "Created"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::PasswordResetRequests#create",
+          "method": "post"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}


### PR DESCRIPTION
notes: Add in the ability to namespace the generated auth token, that is associated in redis. When password reset succeeds, clear the auth off using the namespace for easy identification

Also added in the missing swagger doc for the password reset request endpoint