### PR TITLE
[JJ] Add in the ability for faculty user to have profiles updated

### DIFF
--- a/app/classes/faculty_user_profile_updater.rb
+++ b/app/classes/faculty_user_profile_updater.rb
@@ -1,0 +1,31 @@
+class FacultyUserProfileUpdater < BaseUserProfileUpdater
+  def initialize(user:, profile_params:)
+    super
+    @faculty = user.faculty
+  end
+
+  private
+
+  attr_reader :faculty
+
+  def assign_context_specific_attributes
+    faculty.address1 = address1
+    faculty.address2 = address2
+    faculty.city = city
+    faculty.state = state
+    faculty.zip = zip
+    faculty.name = faculty_name
+    faculty.bio = faculty_bio
+  end
+
+  def context_specific_persist!
+    faculty.save!
+  end
+
+  def extra_params
+    [
+      :faculty_name,
+      :faculty_bio
+    ] 
+  end
+end

--- a/app/classes/parent_user_profile_updater.rb
+++ b/app/classes/parent_user_profile_updater.rb
@@ -1,0 +1,26 @@
+class ParentUserProfileUpdater < BaseUserProfileUpdater
+  def initialize(user:, profile_params:)
+    super
+    @parent = user.parent
+  end
+
+  private
+
+  attr_reader :parent
+
+  def assign_context_specific_attributes
+    parent.address1 = address1
+    parent.address2 = address2
+    parent.city = city
+    parent.state = state
+    parent.zip = zip
+  end
+
+  def context_specific_persist!
+    parent.save! 
+  end
+
+  def extra_params
+    []
+  end
+end

--- a/app/classes/user_profile_serializer.rb
+++ b/app/classes/user_profile_serializer.rb
@@ -6,6 +6,7 @@ class UserProfileSerializer
   def initialize(user)
     @user = user
     @parent = user.parent
+    @faculty = user.faculty
   end
 
   def serialize
@@ -30,12 +31,22 @@ class UserProfileSerializer
           created_at: parent&.created_at,
           updated_at: parent&.updated_at
         },
-        faculty: {}
+        faculty: {
+          faculty_name: faculty&.name,
+          faculty_bio: faculty&.bio,
+          address1: faculty&.address1,
+          address2: faculty&.address2,
+          city: faculty&.city,
+          state: faculty&.state,
+          zip: faculty&.zip,
+          created_at: faculty&.created_at,
+          updated_at: faculty&.updated_at
+        }
       }
     }
   end
 
   private
 
-  attr_reader :user, :parent
+  attr_reader :user, :parent, :faculty
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   include BCrypt
 
   has_one :parent
+  has_one :faculty
   has_many :students, through: :parent
   validates :email, :password_hash, presence: true
 

--- a/db/migrate/20200823060021_add_locale_columns_to_faculties.rb
+++ b/db/migrate/20200823060021_add_locale_columns_to_faculties.rb
@@ -1,0 +1,9 @@
+class AddLocaleColumnsToFaculties < ActiveRecord::Migration[5.2]
+  def change
+    add_column :faculties, :address1, :text
+    add_column :faculties, :address2, :text
+    add_column :faculties, :city, :text
+    add_column :faculties, :state, :text
+    add_column :faculties, :zip, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_16_184733) do
+ActiveRecord::Schema.define(version: 2020_08_23_060021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,11 @@ ActiveRecord::Schema.define(version: 2020_08_16_184733) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "name", null: false
+    t.text "address1"
+    t.text "address2"
+    t.text "city"
+    t.text "state"
+    t.text "zip"
     t.index ["user_id"], name: "index_faculties_on_user_id"
   end
 

--- a/public/api/v1/api/v1/user_profile_changes.json
+++ b/public/api/v1/api/v1/user_profile_changes.json
@@ -19,87 +19,108 @@
             },
             {
               "paramType": "form",
+              "name": "perspective",
+              "type": "string",
+              "description": "User profile perspective (parent|faculty)",
+              "required": true
+            },
+            {
+              "paramType": "form",
               "name": "profile[first_name]",
               "type": "string",
-              "description": "Email Address",
+              "description": "User first name",
               "required": true
             },
             {
               "paramType": "form",
               "name": "profile[last_name]",
               "type": "string",
-              "description": "Password",
+              "description": "User last name",
               "required": true
             },
             {
               "paramType": "form",
               "name": "profile[user_name]",
               "type": "string",
-              "description": "Email Address",
+              "description": "User screen user name",
               "required": true
             },
             {
               "paramType": "form",
               "name": "profile[phone_number]",
               "type": "string",
-              "description": "Password",
+              "description": "User phone number",
               "required": true
             },
             {
               "paramType": "form",
               "name": "profile[emergency_contact]",
               "type": "string",
-              "description": "Email Address",
-              "required": true
+              "description": "User emergency contact",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[emergency_contact_phone_number]",
               "type": "string",
-              "description": "Password",
-              "required": true
+              "description": "User emergency contact phone number",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[timezone]",
               "type": "string",
-              "description": "Email Address",
-              "required": true
+              "description": "User timezone",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[address1]",
               "type": "string",
-              "description": "Password",
-              "required": true
+              "description": "User address1",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[address2]",
               "type": "string",
-              "description": "Email Address",
-              "required": true
+              "description": "User address2",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[city]",
               "type": "string",
-              "description": "Password",
-              "required": true
+              "description": "User city",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[state]",
               "type": "string",
-              "description": "Email Address",
-              "required": true
+              "description": "User state",
+              "required": false
             },
             {
               "paramType": "form",
               "name": "profile[zip]",
               "type": "string",
-              "description": "Password",
-              "required": true
+              "description": "User zip",
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "profile[faculty_name]",
+              "type": "string",
+              "description": "Faculty user name",
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "profile[faculty_bio]",
+              "type": "string",
+              "description": "Faculty user bio",
+              "required": false
             }
           ],
           "responseMessages": [

--- a/spec/requests/api/v1/user_profile_changes_spec.rb
+++ b/spec/requests/api/v1/user_profile_changes_spec.rb
@@ -4,9 +4,7 @@ describe Api::V1::UserProfileChangesController, type: :request do
   include FakeAuthEstablishable
 
   let!(:user) { create(:user, password: 'abcde12345!') }
-  let!(:session_establish_time) { Time.zone.local(2020, 5, 10, 10) }
-  let!(:parent) { create(:parent, user: user) }
-  let(:update_user_profile_params) do
+  let(:base_user_profile_params) do
     {
       profile: {
         first_name: 'Hank',
@@ -30,69 +28,99 @@ describe Api::V1::UserProfileChangesController, type: :request do
   end
 
   describe '#create' do
-    it 'properly saves the profile info' do
-      post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+    context 'as a faculty user' do
+      let!(:faculty) { create(:faculty, user: user) }
+      let(:update_user_profile_params) do
+        base_user_profile_params[:profile][:faculty_name] = 'Miss Garrett the Great'
+        base_user_profile_params[:profile][:faculty_bio] = 'I am a great teacher, trust me'
+ 
+        base_user_profile_params.merge!({ perspective: 'faculty' })
+      end
 
-      expect(response.status).to eq 201
-      body = JSON.parse(response.body).with_indifferent_access
-      expect(body[:profile][:first_name]).to eq 'Hank'
-      expect(body[:profile][:user_name]).to eq 'Tempt'
-      expect(body[:profile][:parent][:address1]).to eq '305 3rd St'
-      expect(body[:profile][:parent][:zip]).to eq '09165'
+      it 'properly saves the profile info' do
+        post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+
+        expect(response.status).to eq 201
+        body = JSON.parse(response.body).with_indifferent_access
+        expect(body[:profile][:first_name]).to eq 'Hank'
+        expect(body[:profile][:user_name]).to eq 'Tempt'
+        expect(body[:profile][:faculty][:address1]).to eq '305 3rd St'
+        expect(body[:profile][:faculty][:zip]).to eq '09165'
+        expect(body[:profile][:faculty][:faculty_name]).to eq 'Miss Garrett the Great'
+        expect(body[:profile][:faculty][:faculty_bio]).to eq 'I am a great teacher, trust me'
+      end
     end
 
-    it 'enables consecutive updates' do
-      post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-
-      expect(response.status).to eq 201
-      update_user_profile_params[:profile][:phone_number] = '616-116-1169'
-      update_user_profile_params[:profile][:emergency_contact] = 'Grant Sonny'
-      post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-      expect(response.status).to eq 201
-      update_user_profile_params[:profile][:user_name] = 'Haniti'
-      post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-      expect(response.status).to eq 201
-
-      expect(JSON.parse(response.body).with_indifferent_access[:profile][:user_name]).to eq 'Haniti'
-    end
-
-    context 'with data malformed or incomplete issues' do
-      it 'encounters an user name already taken error' do
-        create(:user, password: 'aaaeee11122$', user_name: 'Tempt')
-
-        post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-        expect(response.status).to eq 500
-        body = JSON.parse(response.body).with_indifferent_access
-        expect(body[:errors][:profile_mutation_error]).
-          to match /The user name Tempt has already been taken/
+    context 'as a parent user' do
+      let!(:parent) { create(:parent, user: user) }
+      let(:update_user_profile_params) do
+        base_user_profile_params.merge!({ perspective: 'parent' })
       end
 
-      it 'encounters the missing name error' do
-        update_user_profile_params[:profile][:first_name] = nil
+      it 'properly saves the profile info' do
         post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-        expect(response.status).to eq 500
+
+        expect(response.status).to eq 201
         body = JSON.parse(response.body).with_indifferent_access
-        expect(body[:errors][:profile_mutation_error]).
-          to match /You must provide your first and last name/
+        expect(body[:profile][:first_name]).to eq 'Hank'
+        expect(body[:profile][:user_name]).to eq 'Tempt'
+        expect(body[:profile][:parent][:address1]).to eq '305 3rd St'
+        expect(body[:profile][:parent][:zip]).to eq '09165'
       end
 
-      it 'encounters phone number not available error' do
-        update_user_profile_params[:profile][:phone_number] = nil
+      it 'enables consecutive updates' do
         post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-        expect(response.status).to eq 500
-        body = JSON.parse(response.body).with_indifferent_access
-        expect(body[:errors][:profile_mutation_error]).
-          to match /You must provide your phone number/
+
+        expect(response.status).to eq 201
+        update_user_profile_params[:profile][:phone_number] = '616-116-1169'
+        update_user_profile_params[:profile][:emergency_contact] = 'Grant Sonny'
+        post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+        expect(response.status).to eq 201
+        update_user_profile_params[:profile][:user_name] = 'Haniti'
+        post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+        expect(response.status).to eq 201
+
+        expect(JSON.parse(response.body).with_indifferent_access[:profile][:user_name]).to eq 'Haniti'
       end
 
-      it 'encounters address not complete error' do
-        update_user_profile_params[:profile][:city] = nil
-        update_user_profile_params[:profile][:zip] = nil
-        post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
-        expect(response.status).to eq 500
-        body = JSON.parse(response.body).with_indifferent_access
-        expect(body[:errors][:profile_mutation_error]).
-          to match /You must provide your address/
+      context 'with data malformed or incomplete issues' do
+        it 'encounters an user name already taken error' do
+          create(:user, password: 'aaaeee11122$', user_name: 'Tempt')
+
+          post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+          expect(response.status).to eq 500
+          body = JSON.parse(response.body).with_indifferent_access
+          expect(body[:errors][:profile_mutation_error]).
+            to match /The user name Tempt has already been taken/
+        end
+
+        it 'encounters the missing name error' do
+          update_user_profile_params[:profile][:first_name] = nil
+          post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+          expect(response.status).to eq 500
+          body = JSON.parse(response.body).with_indifferent_access
+          expect(body[:errors][:profile_mutation_error]).
+            to match /You must provide your first and last name/
+        end
+
+        it 'encounters phone number not available error' do
+          update_user_profile_params[:profile][:phone_number] = nil
+          post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+          expect(response.status).to eq 500
+          body = JSON.parse(response.body).with_indifferent_access
+          expect(body[:errors][:profile_mutation_error]).
+            to match /You must provide your phone number/
+        end
+
+        it 'encounters address not complete error' do
+          update_user_profile_params[:profile][:city] = nil
+          update_user_profile_params[:profile][:zip] = nil
+          post '/api/v1/user_profile_changes', params: update_user_profile_params, headers: { JWTSessions.access_header => "Bearer #{@token.access}" }
+          expect(response.status).to eq 500
+          body = JSON.parse(response.body).with_indifferent_access
+          expect(body[:errors][:profile_mutation_error]).
+            to match /You must provide your address/
+        end
       end
     end
   end

--- a/spec/requests/api/v1/user_profiles_spec.rb
+++ b/spec/requests/api/v1/user_profiles_spec.rb
@@ -25,7 +25,7 @@ describe Api::V1::UserProfilesController, type: :request do
 
   before do
     establish_valid_token!(user)
-    UserProfileUpdater.update!(user: user, profile_params: profile_populate_data)
+    ParentUserProfileUpdater.update!(user: user, profile_params: profile_populate_data)
   end
 
   it 'encounters forbidden access error' do


### PR DESCRIPTION
- User serialization now returns faculty inner hash
- /api/v1/user_profile_updates now accepts a new `perspective` (parent|faculty) and is now able to properly update based on the passed in perspective and the request body data
