### PR TITLE
[JJ] Add in teaching session model and make linkage based data migrations

### DIFF
--- a/app/models/class_session.rb
+++ b/app/models/class_session.rb
@@ -3,6 +3,7 @@ class ClassSession < ApplicationRecord
 
   belongs_to :registration
   has_many :materials, class_name: 'ClassSessionMaterial', foreign_key: 'class_session_id'
+  belongs_to :associate_teaching_session, class_name: 'TeachingSession', foreign_key: 'associate_teaching_session_id'
 
   validates :registration_id, :effective_for, :status, presence: true
   validates :status, inclusion: { in: VALID_STATUSES }

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -2,6 +2,8 @@ class Klass < ApplicationRecord
   belongs_to :specialty
   belongs_to :faculty
   has_many :registrations
+  has_many :class_sessions, through: :registrations
+  has_many :teaching_sessions
 
   validates :specialty_id,
     :faculty_id,

--- a/app/models/teaching_session.rb
+++ b/app/models/teaching_session.rb
@@ -1,0 +1,4 @@
+class TeachingSession < ApplicationRecord
+  belongs_to :klass
+  has_many :associate_class_sessions, class_name: 'ClassSession', foreign_key: 'associate_teaching_session_id'
+end

--- a/db/migrate/20200908065921_create_teaching_sessions.rb
+++ b/db/migrate/20200908065921_create_teaching_sessions.rb
@@ -1,0 +1,11 @@
+class CreateTeachingSessions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :teaching_sessions do |t|
+      t.references :klass, null: false, index: true, foreign_key: true
+      t.datetime :effective_for, null: false
+      t.text :corresponding_class_session_title
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20200908174356_add_associate_teaching_session_reference_to_class_sessions.rb
+++ b/db/migrate/20200908174356_add_associate_teaching_session_reference_to_class_sessions.rb
@@ -1,0 +1,7 @@
+class AddAssociateTeachingSessionReferenceToClassSessions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :class_sessions, :associate_teaching_session_id, :bigint
+    add_index :class_sessions, :associate_teaching_session_id
+    add_foreign_key :class_sessions, :teaching_sessions, column: 'associate_teaching_session_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_24_052802) do
+ActiveRecord::Schema.define(version: 2020_09_08_174356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,8 @@ ActiveRecord::Schema.define(version: 2020_08_24_052802) do
     t.datetime "effective_for", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "associate_teaching_session_id"
+    t.index ["associate_teaching_session_id"], name: "index_class_sessions_on_associate_teaching_session_id"
     t.index ["registration_id"], name: "index_class_sessions_on_registration_id"
   end
 
@@ -152,6 +154,15 @@ ActiveRecord::Schema.define(version: 2020_08_24_052802) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "teaching_sessions", force: :cascade do |t|
+    t.bigint "klass_id", null: false
+    t.datetime "effective_for", null: false
+    t.text "corresponding_class_session_title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["klass_id"], name: "index_teaching_sessions_on_klass_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.text "email", null: false
     t.text "first_name"
@@ -179,6 +190,7 @@ ActiveRecord::Schema.define(version: 2020_08_24_052802) do
 
   add_foreign_key "class_session_materials", "class_sessions"
   add_foreign_key "class_sessions", "registrations"
+  add_foreign_key "class_sessions", "teaching_sessions", column: "associate_teaching_session_id"
   add_foreign_key "faculties", "users"
   add_foreign_key "family_members", "parents"
   add_foreign_key "family_members", "students"
@@ -186,4 +198,5 @@ ActiveRecord::Schema.define(version: 2020_08_24_052802) do
   add_foreign_key "klasses", "specialties"
   add_foreign_key "parents", "users"
   add_foreign_key "registrations", "klasses"
+  add_foreign_key "teaching_sessions", "klasses"
 end

--- a/docs/DATA_MODEL.html
+++ b/docs/DATA_MODEL.html
@@ -1164,6 +1164,7 @@ updated_at: Timestamp
 registration_id: Bigint
 status: Text
 effective_for: Timestamp
+associate_teaching_session_id: Bigint
 created_at: Timestamp
 updated_at: Timestamp
 </pre></div>
@@ -1174,6 +1175,15 @@ name: Text
 class_session_id: Bigint
 audience: Text
 mime_type: Text
+created_at: Timestamp
+updated_at: Timestamp
+</pre></div>
+
+<p><strong>Teaching Sessions</strong></p>
+<div class="codehilite"><pre>id: Bigint
+klass_id: Bigint
+effective_for: Timestamp
+corresponding_class_session_title: Text
 created_at: Timestamp
 updated_at: Timestamp
 </pre></div></article></body></html>

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -128,6 +128,7 @@ id: Bigint
 registration_id: Bigint
 status: Text
 effective_for: Timestamp
+associate_teaching_session_id: Bigint
 created_at: Timestamp
 updated_at: Timestamp
 ```
@@ -140,6 +141,17 @@ name: Text
 class_session_id: Bigint
 audience: Text
 mime_type: Text
+created_at: Timestamp
+updated_at: Timestamp
+```
+
+__Teaching Sessions__
+
+```
+id: Bigint
+klass_id: Bigint
+effective_for: Timestamp
+corresponding_class_session_title: Text
 created_at: Timestamp
 updated_at: Timestamp
 ```

--- a/lib/tasks/one_off_data_change.rake
+++ b/lib/tasks/one_off_data_change.rake
@@ -29,3 +29,21 @@ task populate_all_classes_zoom_links: :environment do
     end
   end
 end
+
+desc 'generate klasses\'s teaching sessions and link with class sessions'
+task generate_klass_teaching_sessions_and_link_with_class_sessions: :environment do
+  ActiveRecord::Base.transaction do
+    Klass.find_each do |klass|
+      klass.expected_session_dates.each do |date|
+        new_teaching_session = klass.teaching_sessions.create!(effective_for: date + 9.hours)
+
+        klass.class_sessions.each do |class_session|
+          if class_session.effective_for.to_date == new_teaching_session.effective_for.to_date
+            class_session.associate_teaching_session = new_teaching_session
+            class_session.save!
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add in class associated `teaching_sessions` table/model. This will ensure that faculties can interact with an abstract session that has the ability to propagate to students' registered class sessions

Specific modeling details
- klass has many teaching sessions
- a class session associate to a specific teaching session
- a teaching session has many class sessions