### PR TITLE
[JJ] Add in teaching sessions retrieval endpoint for faculty users

### DIFF
--- a/app/models/teaching_session.rb
+++ b/app/models/teaching_session.rb
@@ -1,4 +1,14 @@
 class TeachingSession < ApplicationRecord
   belongs_to :klass
   has_many :associate_class_sessions, class_name: 'ClassSession', foreign_key: 'associate_teaching_session_id'
+
+  def as_serialized_hash
+    {
+      id: id,
+      effective_for: effective_for,
+      corresponding_class_session_title: corresponding_class_session_title,
+      created_at: created_at,
+      updated_at: updated_at
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :authentications, only: [:create]
       resources :authentication_renewals, only: [:create]
-      resources :courses, only: [:index]
+      resources :courses, only: [:index] do
+        member do
+          get 'teaching_sessions'
+        end
+      end
       resources :class_sessions, only: [:show]
       resources :family_members, only: [:create, :index, :destroy]
       resources :password_reset_requests, only: [:create]

--- a/public/api/v1/api/v1/courses.json
+++ b/public/api/v1/api/v1/courses.json
@@ -5,6 +5,42 @@
   "resourcePath": "courses",
   "apis": [
     {
+      "path": "/api/v1/courses/{id}/teaching_sessions.json",
+      "operations": [
+        {
+          "summary": "Retrieve course associated teaching session for eligible faculty users",
+          "parameters": [
+            {
+              "paramType": "query",
+              "name": "id",
+              "type": "integer",
+              "description": "Course unique identifier",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::Courses#teaching_sessions",
+          "method": "get"
+        }
+      ]
+    },
+    {
       "path": "/api/v1/courses.json",
       "operations": [
         {

--- a/spec/factories/teaching_session_factory.rb
+++ b/spec/factories/teaching_session_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :teaching_session do
+    klass
+    effective_for { Time.now }
+    corresponding_class_session_title { 'Some Teaching Session' }
+  end
+end


### PR DESCRIPTION
notes: Add in teaching sessions retrieval endpoint for any eligible faculty user

api contract is: **GET** `/api/v1/courses/:id/teaching_sessions`
