### PR TITLE
[JJ] Add in teaching session student materials upload endpoint

### DIFF
--- a/app/classes/teaching_session_student_materials_creator.rb
+++ b/app/classes/teaching_session_student_materials_creator.rb
@@ -1,0 +1,72 @@
+class TeachingSessionStudentMaterialsCreator
+  def self.create!(teaching_session, material, file_name, file_type)
+    new(teaching_session, material, file_name, file_type).create!
+  end
+
+  def initialize(teaching_session, material, file_name, file_type)
+    @teaching_session = teaching_session
+    @material = material
+    @file_name = file_name
+    @file_type = file_type
+  end
+
+  def create!
+    upload_file_to_s3!
+
+    ActiveRecord::Base.transaction do
+      created_upload = create_teaching_session_student_upload!
+
+      pertinent_class_sessions.each do |session|
+        new_material = session.materials.create!(
+          name: file_name,
+          audience: 'students',
+          mime_type: file_type,
+          teaching_session_student_upload: created_upload
+        )
+      end
+
+      created_upload
+    end
+  end
+
+  private
+
+  attr_reader :teaching_session, :material, :file_name, :file_type
+
+  def klass
+    @klass ||= teaching_session.klass 
+  end
+
+  def pertinent_class_sessions
+    @pertinent_class_sessions ||= begin
+      teaching_session.associate_class_sessions.find_all do |class_session|
+        class_session.effective_for.to_date == effective_for_date
+      end
+    end
+  end
+
+  def effective_for_date
+    @effective_for_date ||= teaching_session.effective_for.to_date 
+  end
+
+  def create_teaching_session_student_upload!
+    TeachingSessionStudentUpload.create!(
+      teaching_session: teaching_session,
+      name: file_name,
+      mime_type: file_type
+    )
+  end
+
+  def upload_file_to_s3!
+    S3FileManager.upload_object(
+      folder_path,
+      file_name,
+      material.read,
+      true
+    )
+  end
+
+  def folder_path
+    @folder_path ||= klass.materials_holding_folder_name
+  end
+end

--- a/app/controllers/api/v1/teaching_sessions_controller.rb
+++ b/app/controllers/api/v1/teaching_sessions_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class TeachingSessionsController < ApplicationController
+      before_action :authorize_access_request!
+
+      swagger_controller :student_session_materials, 'Student Session Materials Management'
+
+      swagger_api :student_materials do
+        summary 'Faculty manage to upload student class session materials'
+        param :header, 'Authorization', :string, :required, 'User procured Acccess Token'
+        param :form, 'student_session_material', :formData, :required, 'Uploaded student session material form file'
+        response :unauthorized
+        response :internal_server_error
+        response :created
+      end
+
+      def student_materials
+        begin
+          raise 'You\'re not permitted to access this teaching session to perform student uploads' unless permitted_to_access_teching_session?
+
+          teaching_session_student_upload = TeachingSessionStudentMaterialsCreator.create!(
+            teaching_session,
+            student_session_material.tempfile,
+            student_session_material.original_filename,
+            student_session_material.content_type
+          )
+
+          render json: { teaching_session_student_upload: teaching_session_student_upload.as_serialized_hash }, status: :created
+        rescue => exception
+          render json: { errors: { student_session_material_creation_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def student_session_material
+        @student_session_material ||= params.require(:student_session_material)
+      end
+
+      def teaching_session
+        @teaching_session ||= TeachingSession.find(params[:id])
+      end
+
+      def permitted_to_access_teching_session?
+        current_user == teaching_session.klass.faculty.user
+      end
+    end
+  end
+end

--- a/app/models/class_session_material.rb
+++ b/app/models/class_session_material.rb
@@ -1,5 +1,6 @@
 class ClassSessionMaterial < ApplicationRecord
   belongs_to :class_session
+  belongs_to :teaching_session_student_upload
 
   validates :name,
     :class_session_id,

--- a/app/models/teaching_session.rb
+++ b/app/models/teaching_session.rb
@@ -1,12 +1,14 @@
 class TeachingSession < ApplicationRecord
   belongs_to :klass
   has_many :associate_class_sessions, class_name: 'ClassSession', foreign_key: 'associate_teaching_session_id'
+  has_many :teaching_session_student_uploads
 
   def as_serialized_hash
     {
       id: id,
       effective_for: effective_for,
       corresponding_class_session_title: corresponding_class_session_title,
+      teaching_session_student_uploads: teaching_session_student_uploads.map(&:as_serialized_hash),
       created_at: created_at,
       updated_at: updated_at
     }

--- a/app/models/teaching_session_student_upload.rb
+++ b/app/models/teaching_session_student_upload.rb
@@ -1,0 +1,15 @@
+class TeachingSessionStudentUpload < ApplicationRecord
+  belongs_to :teaching_session
+  has_many :class_session_materials
+
+  def as_serialized_hash
+    {
+      id: id,
+      teaching_session_id: teaching_session_id,
+      name: name,
+      mime_type: mime_type, 
+      created_at: created_at,
+      updated_at: updated_at
+    }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,8 @@ module AbsNextGenBe
 
     # Setting ActiveJob to use resque
     config.active_job.queue_adapter = :resque
+
+    # set belongs_to to be not default to true
+    Rails.application.config.active_record.belongs_to_required_by_default = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,11 @@ Rails.application.routes.draw do
         end
       end
       resources :sign_ups, only: [:create]
+      resources :teaching_sessions, only: [] do
+        member do
+          post 'student_materials'
+        end
+      end
       resources :user_profiles, only: [:index]
       resources :user_profile_changes, only: [:create]
     end

--- a/db/migrate/20200919185822_create_teaching_session_student_uploads.rb
+++ b/db/migrate/20200919185822_create_teaching_session_student_uploads.rb
@@ -1,0 +1,11 @@
+class CreateTeachingSessionStudentUploads < ActiveRecord::Migration[5.2]
+  def change
+    create_table :teaching_session_student_uploads do |t|
+      t.references :teaching_session, null: false, index: { name: 'idx_ts_student_uploads_on_ts' }, foreign_key: true
+      t.text :name, null: false
+      t.text :mime_type, null: false
+
+      t.timestamps null: false 
+    end
+  end
+end

--- a/db/migrate/20200920190956_add_teaching_session_student_upload_id_to_class_session_materials.rb
+++ b/db/migrate/20200920190956_add_teaching_session_student_upload_id_to_class_session_materials.rb
@@ -1,0 +1,5 @@
+class AddTeachingSessionStudentUploadIdToClassSessionMaterials < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :class_session_materials, :teaching_session_student_upload, index: { name: 'idx_class_sessions_on_teaching_session_student_upload' }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_08_174356) do
+ActiveRecord::Schema.define(version: 2020_09_20_190956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,9 @@ ActiveRecord::Schema.define(version: 2020_09_08_174356) do
     t.text "mime_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "teaching_session_student_upload_id"
     t.index ["class_session_id"], name: "index_class_session_materials_on_class_session_id"
+    t.index ["teaching_session_student_upload_id"], name: "idx_class_sessions_on_teaching_session_student_upload"
   end
 
   create_table "class_sessions", force: :cascade do |t|
@@ -154,6 +156,15 @@ ActiveRecord::Schema.define(version: 2020_09_08_174356) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "teaching_session_student_uploads", force: :cascade do |t|
+    t.bigint "teaching_session_id", null: false
+    t.text "name", null: false
+    t.text "mime_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["teaching_session_id"], name: "idx_ts_student_uploads_on_ts"
+  end
+
   create_table "teaching_sessions", force: :cascade do |t|
     t.bigint "klass_id", null: false
     t.datetime "effective_for", null: false
@@ -198,5 +209,6 @@ ActiveRecord::Schema.define(version: 2020_09_08_174356) do
   add_foreign_key "klasses", "specialties"
   add_foreign_key "parents", "users"
   add_foreign_key "registrations", "klasses"
+  add_foreign_key "teaching_session_student_uploads", "teaching_sessions"
   add_foreign_key "teaching_sessions", "klasses"
 end

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -40,6 +40,10 @@
       "description": "Sign Ups Management"
     },
     {
+      "path": "/api/v1/teaching_sessions.{format}",
+      "description": "Student Session Materials Management"
+    },
+    {
       "path": "/api/v1/user_profiles.{format}",
       "description": "User Profile Retrieval Management"
     },

--- a/public/api/v1/api/v1/student_session_materials.json
+++ b/public/api/v1/api/v1/student_session_materials.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "student_session_materials",
+  "apis": [
+    {
+      "path": "/api/v1/student_session_materials.json",
+      "operations": [
+        {
+          "summary": "Faculty manage to upload student class session materials",
+          "parameters": [
+            {
+              "paramType": "header",
+              "name": "Authorization",
+              "type": "string",
+              "description": "User procured Acccess Token",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "student_session_material[teaching_session_id]",
+              "type": "integer",
+              "description": "Teaching session unique identifier",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "student_session_material[:material]",
+              "type": "formData",
+              "description": "Uploaded student session material form file",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 201,
+              "responseModel": null,
+              "message": "Created"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::StudentSessionMaterials#create",
+          "method": "post"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/public/api/v1/api/v1/teaching_sessions.json
+++ b/public/api/v1/api/v1/teaching_sessions.json
@@ -1,0 +1,52 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "teaching_sessions",
+  "apis": [
+    {
+      "path": "/api/v1/teaching_sessions/{id}/student_materials.json",
+      "operations": [
+        {
+          "summary": "Faculty manage to upload student class session materials",
+          "parameters": [
+            {
+              "paramType": "header",
+              "name": "Authorization",
+              "type": "string",
+              "description": "User procured Acccess Token",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "student_session_material",
+              "type": "formData",
+              "description": "Uploaded student session material form file",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 201,
+              "responseModel": null,
+              "message": "Created"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::TeachingSessions#student_materials",
+          "method": "post"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/spec/fixtures/materials/some-file.pdf
+++ b/spec/fixtures/materials/some-file.pdf
@@ -1,0 +1,1 @@
+some-data

--- a/spec/requests/api/v1/teaching_sessions_spec.rb
+++ b/spec/requests/api/v1/teaching_sessions_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe Api::V1::TeachingSessionsController, type: :request do
+  include FakeAuthEstablishable
+
+  let!(:user) { create(:user, password: 'abcde12345!') }
+  let!(:parent) { create(:parent, user: user) }
+  let!(:student1) { create(:student, first_name: 'Helen', last_name: 'Downty') }
+  let!(:family_member1) { create(:family_member, parent: parent, student: student1) }
+  let!(:faculty_user) { create(:user, password: 'aeiou12345!') }
+  let!(:faculty_user2) { create(:user, password: 'ckediel12345!') }
+  let!(:faculty) { create(:faculty, user: faculty_user) }
+  let!(:faculty2) { create(:faculty, user: faculty_user2) }
+  let!(:class4) { create(:klass, faculty: faculty, effective_from: Time.zone.now - 10.days, effective_until: Time.zone.now + 20.days, reg_effective_from: Time.zone.now - 10.days, reg_effective_until: Time.zone.now + 20.days) }
+  let!(:class5) { create(:klass, faculty: faculty2, effective_from: Time.zone.now - 10.days, effective_until: Time.zone.now + 20.days, reg_effective_from: Time.zone.now - 10.days, reg_effective_until: Time.zone.now + 20.days) }
+  let!(:teaching_session1) { create(:teaching_session, klass: class4, effective_for: class4.expected_session_dates[1]) }
+
+  let!(:registration_1) { create(:registration, klass: class4, primary_family_member: family_member1) }
+  let!(:registration_1_class_sessions) do
+    registration_1.klass.expected_session_dates.map do |specific_date|
+      create(:class_session, registration: registration_1, effective_for: specific_date).tap do |class_session|
+        if class_session.effective_for.to_date == teaching_session1.effective_for.to_date
+          class_session.associate_teaching_session = teaching_session1
+          class_session.save
+        end
+      end
+    end
+  end
+
+  let(:uploading_material) do
+    Rack::Test::UploadedFile.new(
+      File.open(File.join(Rails.root, '/spec/fixtures/materials/some-file.pdf')),
+      'application/pdf'
+    )
+  end
+
+  let!(:create_params) do
+    {
+      student_session_material: uploading_material
+    }
+  end
+
+  before do
+    allow(S3FileManager).to receive(:upload_object)
+  end
+
+  describe '.student_materials' do
+    it 'encounters non permitted teaching session' do
+      establish_valid_token!(faculty_user2)
+      post "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials", params: create_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
+      expect(response.status).to eq 500
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body['errors']['student_session_material_creation_error']).
+        to eq 'You\'re not permitted to access this teaching session to perform student uploads'
+    end
+
+    it 'properly creates the teaching session student uploads and the class sessions materials' do
+      establish_valid_token!(faculty_user)
+
+      expect do
+        post "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials", params: create_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
+      end.to change { TeachingSessionStudentUpload.count }.by(1).
+        and change { ClassSessionMaterial.count }.by(1)
+
+      expect(response.status).to eq 201
+
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body[:teaching_session_student_upload]).to be_present
+
+      created_teaching_session_student_upload = TeachingSessionStudentUpload.last
+      created_class_session_material = ClassSessionMaterial.last
+      expect(created_class_session_material.teaching_session_student_upload).
+        to eq created_teaching_session_student_upload
+      expect(created_class_session_material.class_session.associate_teaching_session).
+        to eq teaching_session1
+    end
+  end
+end


### PR DESCRIPTION
This PR adds in the `POST /api/v1/teaching_sessions/:id/student_materials` endpoint

``` ruby
# Request Payload
{
  student_session_material:
}
```
where the `student_session_material` is expected to be a client side `formData` and to be intercepted by server side, via rack, as `ActionDispatch::Http::UploadedFile`