### PR TITLE
[JJ] Add in teaching session student upload delete endpoint 

### DIFF
--- a/app/classes/teaching_session_student_upload_destroyer.rb
+++ b/app/classes/teaching_session_student_upload_destroyer.rb
@@ -1,0 +1,28 @@
+class TeachingSessionStudentUploadDestroyer
+  def self.destroy!(teaching_session_student_upload)
+    new(teaching_session_student_upload).destroy!
+  end
+
+  def initialize(teaching_session_student_upload)
+    @teaching_session_student_upload = teaching_session_student_upload
+  end
+
+  def destroy!
+    ActiveRecord::Base.transaction do
+      associated_class_session_materials.each(&:destroy)
+      teaching_session_student_upload.destroy!
+
+      teaching_session_student_upload
+    end
+  end
+
+  private
+
+  attr_reader :teaching_session_student_upload
+
+  def associated_class_session_materials
+    @associated_class_sessions ||= begin
+      teaching_session_student_upload.class_session_materials
+    end
+  end
+end

--- a/app/controllers/api/v1/teaching_session_student_uploads_controller.rb
+++ b/app/controllers/api/v1/teaching_session_student_uploads_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class TeachingSessionStudentUploadsController < ApplicationController
+      before_action :authorize_access_request!
+
+      swagger_controller :teaching_session_student_uploads, 'Teaching Session Student Uploads Management'
+
+      swagger_api :destroy do
+        summary 'Deletes student upload and the associated class session materials'
+        param :header, 'Authorization', :string, :required, 'User procured Acccess Token'
+        param :query, 'teaching_session_id', :integer, :required, 'teaching session unique identifier'
+        param :query, 'id', :integer, :required, 'teaching session student upload unique identifier'
+        response :unauthorized
+        response :internal_server_error
+        response :ok
+      end
+
+      def destroy
+        begin
+          raise 'You\'re not permitted to access this teaching session to perform student uploads' unless permitted_to_access_teching_session?
+          raise 'The to be deleted student upload and the accessing teaching session are mismatched' if teaching_session_and_student_upload_not_matching?
+
+          upload = TeachingSessionStudentUploadDestroyer.destroy!(student_upload)
+          render json: { teaching_session_student_upload: upload.as_serialized_hash }, status: :ok
+        rescue => exception
+          render json: { errors: { delete_teaching_session_student_upload_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def permitted_to_access_teching_session?
+        current_user == teaching_session.klass.faculty.user
+      end
+
+      def teaching_session_and_student_upload_not_matching?
+        student_upload.teaching_session != teaching_session
+      end
+
+      def teaching_session
+        @teaching_session ||= TeachingSession.find(params[:teaching_session_id])
+      end
+
+      def student_upload
+        @student_upload ||= TeachingSessionStudentUpload.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -84,6 +84,7 @@ class Klass < ApplicationRecord
         name: faculty.name,
         bio: faculty.bio
       },
+      number_of_weeks: number_of_weeks,
       taught_via: taught_via,
       per_session_student_cost: per_session_student_cost,
       occurs_on_for_a_given_week: occurs_on_for_a_given_week,

--- a/app/models/teaching_session.rb
+++ b/app/models/teaching_session.rb
@@ -3,10 +3,13 @@ class TeachingSession < ApplicationRecord
   has_many :associate_class_sessions, class_name: 'ClassSession', foreign_key: 'associate_teaching_session_id'
   has_many :teaching_session_student_uploads
 
+  delegate :individual_session_starts_at, to: :klass
+
   def as_serialized_hash
     {
       id: id,
       effective_for: effective_for,
+      individual_session_starts_at: individual_session_starts_at,
       corresponding_class_session_title: corresponding_class_session_title,
       teaching_session_student_uploads: teaching_session_student_uploads.map(&:as_serialized_hash),
       created_at: created_at,

--- a/app/models/teaching_session_student_upload.rb
+++ b/app/models/teaching_session_student_upload.rb
@@ -2,10 +2,18 @@ class TeachingSessionStudentUpload < ApplicationRecord
   belongs_to :teaching_session
   has_many :class_session_materials
 
+  def material_access_url
+    S3FileManager.url_for_object(
+      teaching_session.klass.materials_holding_folder_name,
+      name
+    )
+  end
+
   def as_serialized_hash
     {
       id: id,
       teaching_session_id: teaching_session_id,
+      material_access_url: material_access_url,
       name: name,
       mime_type: mime_type, 
       created_at: created_at,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         member do
           post 'student_materials'
         end
+        resources :student_materials, controller: 'teaching_session_student_uploads', only: [:destroy]
       end
       resources :user_profiles, only: [:index]
       resources :user_profile_changes, only: [:create]

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -44,6 +44,10 @@
       "description": "Student Session Materials Management"
     },
     {
+      "path": "/api/v1/teaching_session_student_uploads.{format}",
+      "description": "Teaching Session Student Uploads Management"
+    },
+    {
       "path": "/api/v1/user_profiles.{format}",
       "description": "User Profile Retrieval Management"
     },

--- a/public/api/v1/api/v1/teaching_session_student_uploads.json
+++ b/public/api/v1/api/v1/teaching_session_student_uploads.json
@@ -1,0 +1,59 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "teaching_session_student_uploads",
+  "apis": [
+    {
+      "path": "/api/v1/teaching_sessions/{teaching_session_id}/student_materials/{id}.json",
+      "operations": [
+        {
+          "summary": "Deletes student upload and the associated class session materials",
+          "parameters": [
+            {
+              "paramType": "header",
+              "name": "Authorization",
+              "type": "string",
+              "description": "User procured Acccess Token",
+              "required": true
+            },
+            {
+              "paramType": "query",
+              "name": "teaching_session_id",
+              "type": "integer",
+              "description": "teaching session unique identifier",
+              "required": true
+            },
+            {
+              "paramType": "query",
+              "name": "id",
+              "type": "integer",
+              "description": "teaching session student upload unique identifier",
+              "required": true
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "responseModel": null,
+              "message": "Ok"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::TeachingSessionStudentUploads#destroy",
+          "method": "delete"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/spec/factories/teching_session_student_upload_factory.rb
+++ b/spec/factories/teching_session_student_upload_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :teaching_session_student_upload do
+    teaching_session
+    name { 'some-file.pdf' }
+    mime_type { 'application/pdf' }
+  end
+end

--- a/spec/requests/api/v1/teaching_session_student_uploads_spec.rb
+++ b/spec/requests/api/v1/teaching_session_student_uploads_spec.rb
@@ -8,13 +8,12 @@ describe Api::V1::TeachingSessionsController, type: :request do
   let!(:student1) { create(:student, first_name: 'Helen', last_name: 'Downty') }
   let!(:family_member1) { create(:family_member, parent: parent, student: student1) }
   let!(:faculty_user) { create(:user, password: 'aeiou12345!') }
-  let!(:faculty_user2) { create(:user, password: 'ckediel12345!') }
   let!(:faculty) { create(:faculty, user: faculty_user) }
+  let!(:faculty_user2) { create(:user, password: 'ckediel12345!') }
   let!(:faculty2) { create(:faculty, user: faculty_user2) }
   let!(:class4) { create(:klass, faculty: faculty, effective_from: Time.zone.now - 10.days, effective_until: Time.zone.now + 20.days, reg_effective_from: Time.zone.now - 10.days, reg_effective_until: Time.zone.now + 20.days) }
   let!(:class5) { create(:klass, faculty: faculty2, effective_from: Time.zone.now - 10.days, effective_until: Time.zone.now + 20.days, reg_effective_from: Time.zone.now - 10.days, reg_effective_until: Time.zone.now + 20.days) }
   let!(:teaching_session1) { create(:teaching_session, klass: class4, effective_for: class4.expected_session_dates[1]) }
-
   let!(:registration_1) { create(:registration, klass: class4, primary_family_member: family_member1) }
   let!(:registration_1_class_sessions) do
     registration_1.klass.expected_session_dates.map do |specific_date|
@@ -27,53 +26,51 @@ describe Api::V1::TeachingSessionsController, type: :request do
     end
   end
 
-  let(:uploading_material) do
-    Rack::Test::UploadedFile.new(
-      File.open(File.join(Rails.root, '/spec/fixtures/materials/some-file.pdf')),
-      'application/pdf'
-    )
-  end
-
-  let!(:create_params) do
-    {
-      student_session_material: uploading_material
-    }
-  end
+  let!(:teaching_session2) { create(:teaching_session, klass: class4, effective_for: class5.expected_session_dates[1]) }
+  let!(:student_upload_for_teaching_session2) { create(:teaching_session_student_upload, teaching_session: teaching_session2, name: 'another-file.pdf') }
 
   before do
     allow(S3FileManager).to receive(:upload_object)
     allow(S3FileManager).to receive(:url_for_object)
+    @upload = TeachingSessionStudentMaterialsCreator.create!(
+      teaching_session1,
+      File.open(File.join(Rails.root, '/spec/fixtures/materials/some-file.pdf')),
+      'some-file.pdf',
+      'application/pdf'
+    )
   end
 
-  describe '.student_materials' do
-    it 'encounters non permitted teaching session' do
+  describe '#destroy' do
+    it 'raises error when teaching session is not accessible' do
       establish_valid_token!(faculty_user2)
-      post "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials", params: create_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
+
+      delete "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials/#{@upload.id}", headers: { 'Authorization' => "Bearer #{@token.access}" }
       expect(response.status).to eq 500
       body = JSON.parse(response.body).with_indifferent_access
-      expect(body['errors']['student_session_material_creation_error']).
-        to eq 'You\'re not permitted to access this teaching session to perform student uploads'
+      expect(body[:errors][:delete_teaching_session_student_upload_error]).
+        to match /not permitted to access this teaching session/
     end
 
-    it 'properly creates the teaching session student uploads and the class sessions materials' do
+    it 'raises teaching session and student upload mismatched error' do
+      establish_valid_token!(faculty_user)
+      delete "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials/#{student_upload_for_teaching_session2.id}", headers: { 'Authorization' => "Bearer #{@token.access}" }
+      expect(response.status).to eq 500
+      body = JSON.parse(response.body).with_indifferent_access
+      expect(body[:errors][:delete_teaching_session_student_upload_error]).
+        to match /to be deleted student upload and the accessing teaching session are mismatched/
+    end
+
+    it 'properly deletes the teaching session student upload, as well as the associated class session materials' do
       establish_valid_token!(faculty_user)
 
       expect do
-        post "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials", params: create_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
-      end.to change { TeachingSessionStudentUpload.count }.by(1).
-        and change { ClassSessionMaterial.count }.by(1)
+        delete "/api/v1/teaching_sessions/#{teaching_session1.id}/student_materials/#{@upload.id}", headers: { 'Authorization' => "Bearer #{@token.access}" }
+      end.to change { ClassSessionMaterial.count }.by(-1).
+        and change { TeachingSessionStudentUpload.count }.by(-1)
 
-      expect(response.status).to eq 201
-
+      expect(response.status).to eq 200
       body = JSON.parse(response.body).with_indifferent_access
-      expect(body[:teaching_session_student_upload]).to be_present
-
-      created_teaching_session_student_upload = TeachingSessionStudentUpload.last
-      created_class_session_material = ClassSessionMaterial.last
-      expect(created_class_session_material.teaching_session_student_upload).
-        to eq created_teaching_session_student_upload
-      expect(created_class_session_material.class_session.associate_teaching_session).
-        to eq teaching_session1
+      expect(body[:teaching_session_student_upload][:id]).to eq @upload.id
     end
   end
 end


### PR DESCRIPTION
notes: Add in teaching session student upload delete endpoint, which deletes the upload and the associated class session materials

`/api/v1/teaching_sessions/:teaching_session_id/class_materials/:id`

Also this PR, fixes a previous issue, where the teaching session endpoint responses didn't serialize back the associated classes' `individual_session_starts_at` property, which is now addressed in this PR.