### PR TITLE
[JJ] Add in a new registrations endpoint to register a class with a credit card

### DIFF
--- a/app/controllers/api/v1/new_registrations_controller.rb
+++ b/app/controllers/api/v1/new_registrations_controller.rb
@@ -1,0 +1,96 @@
+module Api
+  module V1
+    class NewRegistrationsController < ApplicationController
+      before_action :authorize_access_request!
+
+      swagger_controller :registrations, 'New Registrations Management'
+
+      swagger_api :create do
+        summary 'Creating/Registering a class for a set of family members'
+        param :header, 'Authorization', :string, :required, 'User procured Acccess Token'
+        param :form, 'user_email', :string, :required, 'Parent user email'
+        param :form, 'registration[:credit_card_id]', :integer, :optional, 'Registrating user\'s credit card identifier'
+        param :form, 'registration[:charge_amount]', :integer, :required, 'Registertion\'s charging amount'
+        param :form, 'registration[:course_id]', :string, :required, 'Registering class\'s id'
+        param :form, 'registration[primary_family_member_id]', :string, :required, 'First registering family member id'
+        param :form, 'registration[:secondary_family_member_id]', :string, :optional, 'Second registering family member id'
+        param :form, 'registration[:tertiary_family_member_id]', :string, :optional, 'Third registering family member id'
+        param :form, 'registration[accept_release_form]', :boolean, :optional, 'Whether the registering parent accepts the video/audio release form'
+        response :unauthorized
+        response :internal_server_error
+        response :created
+      end
+
+      def create
+        begin
+          raise "Attempt to register with an unauthorized user with email: #{user_email}" if unauthorized_access?
+
+          ActiveRecord::Base.transaction do
+            registration = RegistrationCreator.create!(
+              current_user,
+              registration_create_params[:course_id],
+              registration_create_params[:accept_release_form] || false,
+              family_member1,
+              family_member2,
+              family_member3,
+              registration_create_params[:charge_amount].to_f
+            )
+
+            RegistrationChargeCapturer.capture!(
+              registration,
+              registration_create_params[:charge_amount],
+              credit_card
+            )
+
+            render json: { registration: registration.as_serialized_hash }, status: :created
+          end
+        rescue RegistrationCreator::CreationError, RegistrationChargeCapturer::CaptureError => exception
+          render json: { errors: { registration_creation_error: exception.to_s } }, status: :internal_server_error
+        end
+      end
+
+      private
+
+      def user_email
+        params.require(:user_email)
+      end
+
+      def unauthorized_access?
+        user_email != current_user.email
+      end
+
+      def family_member1
+        (registration_create_params[:primary_family_member_id] &&
+          FamilyMember.where(id: registration_create_params[:primary_family_member_id]).first).presence
+      end
+
+      def family_member2
+        (registration_create_params[:secondary_family_member_id] &&
+          FamilyMember.where(id: registration_create_params[:secondary_family_member_id]).first).presence
+      end
+
+      def family_member3
+        (registration_create_params[:tertiary_family_member_id] &&
+          FamilyMember.where(id: registration_create_params[:tertiary_family_member_id]).first).presence
+      end
+
+      def credit_card
+        @credit_card ||= current_user.credit_cards.find(registration_create_params[:credit_card_id]) 
+      end
+
+      def registration_create_params
+        params.
+          require(:registration).
+          permit(
+            :course_id,
+            :credit_card_id,
+            :charge_amount,
+            :primary_family_member_id,
+            :secondary_family_member_id,
+            :tertiary_family_member_id,
+            :accept_release_form
+          )
+      end
+    end
+  end
+end

--- a/app/models/registration_credit_card_charge.rb
+++ b/app/models/registration_credit_card_charge.rb
@@ -4,7 +4,12 @@ class RegistrationCreditCardCharge < ApplicationRecord
 
   def as_serialized_hash
     {
-      id: id
+      id: id,
+      credit_card_id: credit_card_id,
+      registration_id: registration_id,
+      charge_id: charge_id,
+      created_at: created_at,
+      updated_at: updated_at
     }
   end
 end

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,1 @@
+Stripe.api_key = configatron.stripe.api_secret

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
           post 'charge_amounts'
         end
       end
+      resources :new_registrations, only: [:create]
       resources :sign_ups, only: [:create]
       resources :teaching_sessions, only: [] do
         member do

--- a/public/api/v1/api-docs.json
+++ b/public/api/v1/api-docs.json
@@ -40,6 +40,10 @@
       "description": "Registrations Management"
     },
     {
+      "path": "/api/v1/new_registrations.{format}",
+      "description": "New Registrations Management"
+    },
+    {
       "path": "/api/v1/sign_ups.{format}",
       "description": "Sign Ups Management"
     },

--- a/public/api/v1/api/v1/new_registrations.json
+++ b/public/api/v1/api/v1/new_registrations.json
@@ -1,0 +1,101 @@
+{
+  "apiVersion": "1.0",
+  "swaggerVersion": "1.2",
+  "basePath": "http://api.somedomain.com",
+  "resourcePath": "new_registrations",
+  "apis": [
+    {
+      "path": "/api/v1/new_registrations.json",
+      "operations": [
+        {
+          "summary": "Creating/Registering a class for a set of family members",
+          "parameters": [
+            {
+              "paramType": "header",
+              "name": "Authorization",
+              "type": "string",
+              "description": "User procured Acccess Token",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "user_email",
+              "type": "string",
+              "description": "Parent user email",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "registration[:credit_card_id]",
+              "type": "integer",
+              "description": "Registrating user's credit card identifier",
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "registration[:charge_amount]",
+              "type": "integer",
+              "description": "Registertion's charging amount",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "registration[:course_id]",
+              "type": "string",
+              "description": "Registering class's id",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "registration[primary_family_member_id]",
+              "type": "string",
+              "description": "First registering family member id",
+              "required": true
+            },
+            {
+              "paramType": "form",
+              "name": "registration[:secondary_family_member_id]",
+              "type": "string",
+              "description": "Second registering family member id",
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "registration[:tertiary_family_member_id]",
+              "type": "string",
+              "description": "Third registering family member id",
+              "required": false
+            },
+            {
+              "paramType": "form",
+              "name": "registration[accept_release_form]",
+              "type": "boolean",
+              "description": "Whether the registering parent accepts the video/audio release form",
+              "required": false
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 201,
+              "responseModel": null,
+              "message": "Created"
+            },
+            {
+              "code": 401,
+              "responseModel": null,
+              "message": "Unauthorized"
+            },
+            {
+              "code": 500,
+              "responseModel": null,
+              "message": "Internal Server Error"
+            }
+          ],
+          "nickname": "Api::V1::NewRegistrations#create",
+          "method": "post"
+        }
+      ]
+    }
+  ],
+  "authorizations": null
+}

--- a/spec/requests/api/v1/new_registrations_spec.rb
+++ b/spec/requests/api/v1/new_registrations_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Api::V1::NewRegistrationsController, type: :request do
+  include FakeAuthEstablishable
+
+  let!(:user) { create(:user, password: 'abcde12345!') }
+  let!(:credit_card) { create(:credit_card, user: user, ) }
+  let!(:parent) { create(:parent, user: user) }
+  let!(:student1) { create(:student, first_name: 'Helen', last_name: 'Downty') }
+  let!(:student2) { create(:student, first_name: 'Sammy', last_name: 'Duncan') }
+  let!(:family_member1) { create(:family_member, parent: parent, student: student1) }
+  let!(:family_member2) { create(:family_member, parent: parent, student: student2) }
+  let!(:faculty_user) { create(:user, password: 'aeiou12345!') }
+  let!(:faculty) { create(:faculty, user: faculty_user) }
+  let!(:class1) { create(:klass, faculty: faculty, effective_from: Time.zone.now - 3.days, effective_until: Time.zone.now + 7.days, reg_effective_from: Time.zone.now - 3.days, reg_effective_until: Time.zone.now + 7.days) }
+
+  before do
+    establish_valid_token!(user)
+  end
+
+  describe '#create' do
+    let!(:expected_amount) { CourseFeeCalculator.calculate!(class1, family_member1, family_member2) }
+    let(:create_params) do
+      {
+        user_email: user.email,
+        registration: {
+          course_id: class1.id,
+          charge_amount: expected_amount,
+          credit_card_id: credit_card.id,
+          accept_release_form: true,
+          primary_family_member_id: family_member1.id,
+          secondary_family_member_id: family_member2.id
+        }
+      }
+    end
+
+    before do
+      allow(Stripe::Charge).to receive(:create).and_return({ id: 'this-is-a-successful-charge-id', outcome: {} })
+      @fake_mailer = double('fake_mailer', deliver_now: nil)
+      allow(RegistrationMailer).to receive(:registration_confirmation).and_return(@fake_mailer)
+      allow(RegistrationMailer).to receive(:aba_admin_registration_notification).and_return(@fake_mailer)
+    end
+
+    it 'registers the course for the family members' do
+      expect do
+        post '/api/v1/new_registrations', params: create_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
+      end.to change { Registration.count }.by(1).
+        and change { RegistrationCreditCardCharge.count }.by(1)
+
+      registration = Registration.last
+      registration_credit_card_charge = RegistrationCreditCardCharge.last
+      expect(registration_credit_card_charge.credit_card).to eq credit_card
+      expect(registration_credit_card_charge.charge_id).to eq 'this-is-a-successful-charge-id'
+      expect(registration_credit_card_charge.registration).to eq registration
+      expect(registration.total_due).to eq expected_amount
+    end
+  end
+end


### PR DESCRIPTION
notes:  Add in a new registrations endpoint to incorporate the capability to immediately capture the charge of the amount to be paid for the class

`POST /api/v1/new_registrations`