### PR TITLE
[JJ] Add in the ability to cap class size limit

### DIFF
--- a/app/classes/registration_creator.rb
+++ b/app/classes/registration_creator.rb
@@ -28,6 +28,7 @@ class RegistrationCreator
 
   def create!
     begin
+      raise 'The class you\'re attempting to register has reached its size limit' if reached_class_capacity?
       raise 'You cannot register without a family member' unless family_member1_exists?
       raise 'You are attempting to register with an invalid 2nd family member' unless family_member2_exists_and_valid?
       raise 'You are attempting to register with an invalid 3rd family member' unless family_member3_exists_and_valid?
@@ -60,6 +61,10 @@ class RegistrationCreator
     :family_member2,
     :family_member3,
     :charge_amount
+
+  def reached_class_capacity?
+    course.capacity_reached?
+  end
 
   def total_due_not_matched_with_expected_pay?
     charge_amount != calculated_total_due!

--- a/app/jobs/paid_class_sessions_create_job.rb
+++ b/app/jobs/paid_class_sessions_create_job.rb
@@ -5,7 +5,7 @@ class PaidClassSessionsCreateJob < ApplicationJob
     return unless registration.paid?
 
     registration.klass.remaining_session_dates_from_reference_date(registration.created_at).each do |specific_date|
-      associate_teaching_session = r.klass.teaching_sessions.detect { |ts| ts.effective_for.to_date == specific_date.to_date }
+      associate_teaching_session = registration.klass.teaching_sessions.detect { |ts| ts.effective_for.to_date == specific_date.to_date }
 
       registration.class_sessions.create!(
         status: 'upcoming',
@@ -19,7 +19,7 @@ class PaidClassSessionsCreateJob < ApplicationJob
     return unless registration.paid?
 
     registration.klass.remaining_session_dates_from_reference_date(registration.created_at).each do |specific_date|
-      associate_teaching_session = r.klass.teaching_sessions.detect { |ts| ts.effective_for.to_date == specific_date.to_date }
+      associate_teaching_session = registration.klass.teaching_sessions.detect { |ts| ts.effective_for.to_date == specific_date.to_date }
 
       registration.class_sessions.create!(
         status: 'upcoming',

--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -40,6 +40,14 @@ class Klass < ApplicationRecord
     )
   end
 
+  def capacity_reached?
+    available_spots <= 0
+  end
+
+  def available_spots
+    capacity - registrations.eligible.count
+  end
+
   def vacay_date_strings
     klass_vacay_dates.map(&:off_date)
   end
@@ -105,7 +113,11 @@ class Klass < ApplicationRecord
       effective_until: effective_until,
       reg_effective_from: reg_effective_from,
       reg_effective_until: reg_effective_until,
-      virtual_klass_platform_link: virtual_klass_platform_link
+      virtual_klass_platform_link: virtual_klass_platform_link,
+      capacity: capacity,
+      available_spots: available_spots,
+      created_at: created_at,
+      updated_at: updated_at
     }
   end
 end

--- a/db/migrate/20201205195438_add_capacity_to_klasses.rb
+++ b/db/migrate/20201205195438_add_capacity_to_klasses.rb
@@ -1,0 +1,5 @@
+class AddCapacityToKlasses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :klasses, :capacity, :integer, null: false, default: 20
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_25_203645) do
+ActiveRecord::Schema.define(version: 2020_12_05_195438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,6 +117,7 @@ ActiveRecord::Schema.define(version: 2020_10_25_203645) do
     t.datetime "reg_effective_from"
     t.datetime "reg_effective_until"
     t.integer "student_capacity", default: 100, null: false
+    t.integer "capacity", default: 20, null: false
     t.index ["code"], name: "index_klasses_on_code"
     t.index ["effective_from", "effective_until"], name: "idx_klasses_on_effective_from_to_until"
     t.index ["faculty_id", "specialty_id", "effective_from"], name: "idx_klasses_on_uniq_faculty_specialty_start_time", unique: true

--- a/spec/factories/klass_factory.rb
+++ b/spec/factories/klass_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     one_sibling_same_class_discount_rate { 50.0 }
     two_siblings_same_class_discount_rate { 50.0 }
     virtual_klass_platform_link { 'https://www.zoom.com/123456' }
+    capacity { 10 }
 
     trait :virtual_class do
       taught_via { 'Zoom' }


### PR DESCRIPTION
notes: Make sure each class can have a `capacity` property that holds the upper bound limit of registrations for the class. When limit is hit, any attempted registration will fail.