### PR TITLE
[JJ] Charge amount endpoint now returns specification hash instead a single value

### DIFF
--- a/app/classes/course_fee_calculator.rb
+++ b/app/classes/course_fee_calculator.rb
@@ -15,7 +15,11 @@ class CourseFeeCalculator
   def calculate!
     raise CalculationError.new('Unable to calculate course cost without a specified registering student') unless primary_family_member.present?
 
-    member1_fee + member2_fee + member3_fee
+    {
+      course_subtotal: course_subtotal,
+      handling_fee: handling_fee,
+      total: course_subtotal + handling_fee
+    }
   end
 
   private
@@ -24,6 +28,14 @@ class CourseFeeCalculator
     :primary_family_member,
     :secondary_family_member,
     :tertiary_family_member
+
+  def course_subtotal
+    @course_subtotal ||= member1_fee + member2_fee + member3_fee 
+  end
+
+  def handling_fee
+    handling_fee ||= course.handling_fee
+  end
 
   def per_student_cost
     course.per_session_student_cost 

--- a/app/classes/registration_creator.rb
+++ b/app/classes/registration_creator.rb
@@ -67,7 +67,7 @@ class RegistrationCreator
   end
 
   def total_due_not_matched_with_expected_pay?
-    charge_amount != calculated_total_due!
+    charge_amount != calculated_total_due_specification!.total
   end
 
   def family_member1_exists?
@@ -99,14 +99,23 @@ class RegistrationCreator
       primary_family_member_id: family_member1.id,
       secondary_family_member_id: family_member2&.id,
       tertiary_family_member_id: family_member3&.id,
-      total_due: calculated_total_due!,
+      total_due: calculated_total_due_specification!.total,
       total_due_by: due_date,
       status: 'pending'
-    } 
+    }
   end
 
-  def calculated_total_due!
-    @_calculated_total_due ||= CourseFeeCalculator.calculate!(course, family_member1, family_member2, family_member3)
+  def calculated_total_due_specification!
+    @calculated_total_due_specification ||= begin
+      OpenStruct.new(
+        CourseFeeCalculator.calculate!(
+          course,
+          family_member1,
+          family_member2,
+          family_member3
+        )
+      )
+    end
   end
 
   def course

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -93,14 +93,14 @@ module Api
         begin
           raise "Unauthorized access: unable to request class's charge amount for incompatible user" if unauthorized_access?
           course = Klass.find(charge_amount_request_params[:course_id])
-          amount = CourseFeeCalculator.calculate!(
+          amount_specification = CourseFeeCalculator.calculate!(
             course,
             charge_amount_calculation_family_member1,
             charge_amount_calculation_family_member2,
             charge_amount_calculation_family_member3
           )
 
-          render json: { amount: amount }, status: :ok
+          render json: { amount_specification: amount_specification }, status: :ok
         rescue => exception
           render json: { charge_amount_calculation_error: exception.to_s }, status: :internal_server_error
         end

--- a/db/migrate/20201208061219_add_handling_fee_to_klasses.rb
+++ b/db/migrate/20201208061219_add_handling_fee_to_klasses.rb
@@ -1,0 +1,5 @@
+class AddHandlingFeeToKlasses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :klasses, :handling_fee, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_05_195438) do
+ActiveRecord::Schema.define(version: 2020_12_08_061219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2020_12_05_195438) do
     t.datetime "reg_effective_until"
     t.integer "student_capacity", default: 100, null: false
     t.integer "capacity", default: 20, null: false
+    t.integer "handling_fee", default: 0, null: false
     t.index ["code"], name: "index_klasses_on_code"
     t.index ["effective_from", "effective_until"], name: "idx_klasses_on_effective_from_to_until"
     t.index ["faculty_id", "specialty_id", "effective_from"], name: "idx_klasses_on_uniq_faculty_specialty_start_time", unique: true

--- a/spec/requests/api/v1/new_registrations_spec.rb
+++ b/spec/requests/api/v1/new_registrations_spec.rb
@@ -19,7 +19,7 @@ describe Api::V1::NewRegistrationsController, type: :request do
   end
 
   describe '#create' do
-    let!(:expected_amount) { CourseFeeCalculator.calculate!(class1, family_member1, family_member2) }
+    let!(:expected_amount) { OpenStruct.new(CourseFeeCalculator.calculate!(class1, family_member1, family_member2)).total }
     let(:create_params) do
       {
         user_email: user.email,

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -48,7 +48,10 @@ describe Api::V1::RegistrationsController, type: :request do
       post '/api/v1/registrations/charge_amounts', params: charge_amount_request_params, headers: { 'Authorization' => "Bearer #{@token.access}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body).with_indifferent_access
-      expect(body[:amount]).to eq 6000
+
+      expect(body[:amount_specification][:course_subtotal]).to eq 6000
+      expect(body[:amount_specification][:handling_fee]).to eq 0
+      expect(body[:amount_specification][:total]).to eq 6000
     end
   end
 


### PR DESCRIPTION
notes: Change charge amount endpoint to return a specification with `subtotal`, `handling fee` and also `total`.