### PR TITLE
[JJ] Make the new reg endpoint able to bypass direct payment and pay later

### DIFF
--- a/app/classes/course_fee_calculator.rb
+++ b/app/classes/course_fee_calculator.rb
@@ -1,6 +1,8 @@
 class CourseFeeCalculator
   class CalculationError < StandardError; end
 
+  HANDLING_FEE_PERCENTAGE = 0.045
+
   def self.calculate!(course, primary_family_member, secondary_family_member = nil, tertiary_family_member = nil)
     new(course, primary_family_member, secondary_family_member, tertiary_family_member).calculate!
   end
@@ -34,7 +36,7 @@ class CourseFeeCalculator
   end
 
   def handling_fee
-    handling_fee ||= course.handling_fee
+    handling_fee ||= (course_subtotal * HANDLING_FEE_PERCENTAGE).round
   end
 
   def per_student_cost

--- a/app/classes/post_registration_notifier.rb
+++ b/app/classes/post_registration_notifier.rb
@@ -1,0 +1,35 @@
+class PostRegistrationNotifier
+  def self.notify(registration)
+    new(registration).notify
+  end
+
+  def initialize(registration)
+    @registration = registration
+  end
+
+  def notify
+    if registration_paid?
+      send_paid_notification_to_parent_user
+    else
+      send_unpaid_notification_to_parent_user
+    end
+
+    RegistrationMailer.aba_admin_registration_notification(registration).deliver_now
+  end
+
+  private
+
+  attr_reader :registration
+
+  def registration_paid?
+    registration.paid?
+  end
+
+  def send_paid_notification_to_parent_user
+    RegistrationMailer.registration_with_fees_paid_confirmation(registration).deliver_now
+  end
+
+  def send_unpaid_notification_to_parent_user
+    RegistrationMailer.registration_confirmation(registration).deliver_now
+  end
+end

--- a/app/classes/registration_charge_capturer.rb
+++ b/app/classes/registration_charge_capturer.rb
@@ -19,9 +19,6 @@ class RegistrationChargeCapturer
         stripe_charge_response = Stripe::Charge.create(charge_capture_params)
         registration_credit_card_charge.update!(charge_id: stripe_charge_response[:id], charge_outcome: stripe_charge_response[:outcome])
         registration.paid!
-
-        RegistrationMailer.registration_with_fees_paid_confirmation(registration).deliver_now
-        RegistrationMailer.aba_admin_registration_notification(registration).deliver_now
       end
     end
   rescue Stripe::CardError,

--- a/app/classes/registration_creator.rb
+++ b/app/classes/registration_creator.rb
@@ -35,14 +35,7 @@ class RegistrationCreator
       raise 'Not all of the specified family members are from the same family' unless family_members_together?
       raise 'Specified total charge amount #{charge_amount} is incorrect' if charge_amount.present? && total_due_not_matched_with_expected_pay?
 
-      registration = Registration.create!(registration_create_params)
-      
-      unless charge_amount.present?
-        RegistrationMailer.registration_confirmation(registration).deliver_now
-        RegistrationMailer.aba_admin_registration_notification(registration).deliver_now
-      end
-
-      registration
+      Registration.create!(registration_create_params)
     rescue => exception
       if exception.to_s.match(/uniq_klass_primary_family_membe/)
         raise CreationError.new('You cannot have your kid(s) register the same class more than once')

--- a/app/classes/registration_creator.rb
+++ b/app/classes/registration_creator.rb
@@ -33,7 +33,7 @@ class RegistrationCreator
       raise 'You are attempting to register with an invalid 2nd family member' unless family_member2_exists_and_valid?
       raise 'You are attempting to register with an invalid 3rd family member' unless family_member3_exists_and_valid?
       raise 'Not all of the specified family members are from the same family' unless family_members_together?
-      raise 'Specified total charge amount #{charge_amount} is incorrect' if charge_amount.present? && total_due_not_matched_with_expected_pay?
+      raise "Specified total charge amount #{charge_amount} is incorrect" if charge_amount.present? && total_due_not_matched_with_expected_pay?
 
       Registration.create!(registration_create_params)
     rescue => exception
@@ -92,7 +92,9 @@ class RegistrationCreator
       primary_family_member_id: family_member1.id,
       secondary_family_member_id: family_member2&.id,
       tertiary_family_member_id: family_member3&.id,
+      subtotal: calculated_total_due_specification!.course_subtotal,
       total_due: calculated_total_due_specification!.total,
+      handling_fee: calculated_total_due_specification!.handling_fee,
       total_due_by: due_date,
       status: 'pending'
     }

--- a/app/controllers/api/v1/new_registrations_controller.rb
+++ b/app/controllers/api/v1/new_registrations_controller.rb
@@ -33,7 +33,7 @@ module Api
               family_member1,
               family_member2,
               family_member3,
-              registration_create_params[:charge_amount].to_f
+              registration_create_params[:charge_amount]
             )
 
             unless pay_later?

--- a/app/controllers/api/v1/registrations_controller.rb
+++ b/app/controllers/api/v1/registrations_controller.rb
@@ -31,6 +31,8 @@ module Api
             family_member2,
             family_member3
           )
+
+          PostRegistrationNotifier.notify(registration.reload)
           render json: { registration: registration.as_serialized_hash }, status: :created
         rescue RegistrationCreator::CreationError => exception
           render json: { errors: { registration_creation_error: exception.to_s } }, status: :internal_server_error

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -63,6 +63,8 @@ class Registration < ApplicationRecord
       tertiary_family_member_id: tertiary_family_member_id,
       total_due: total_due,
       total_due_by: total_due_by,
+      handling_fee: handling_fee,
+      subtotal: subtotal,
       created_at: created_at,
       updated_at: updated_at
     }

--- a/db/migrate/20201217065443_add_handling_fee_and_subtotal_to_registrations.rb
+++ b/db/migrate/20201217065443_add_handling_fee_and_subtotal_to_registrations.rb
@@ -1,0 +1,6 @@
+class AddHandlingFeeAndSubtotalToRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :registrations, :handling_fee, :integer, null: false, default: 0
+    add_column :registrations, :subtotal, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_061219) do
+ActiveRecord::Schema.define(version: 2020_12_17_065443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,6 +166,8 @@ ActiveRecord::Schema.define(version: 2020_12_08_061219) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "accept_release_form", default: false, null: false
+    t.integer "handling_fee", default: 0, null: false
+    t.integer "subtotal", default: 0, null: false
     t.index ["klass_id", "primary_family_member_id"], name: "idx_registrations_on_uniq_klass_primary_family_member", unique: true
     t.index ["klass_id"], name: "index_registrations_on_klass_id"
     t.index ["primary_family_member_id"], name: "index_registrations_on_primary_family_member_id"

--- a/spec/classes/registration_charge_capturer_spec.rb
+++ b/spec/classes/registration_charge_capturer_spec.rb
@@ -15,8 +15,6 @@ describe RegistrationChargeCapturer do
 
   before do
     @fake_mailer = double('fake_mailer', deliver_now: nil)
-    allow(RegistrationMailer).to receive(:registration_with_fees_paid_confirmation).and_return(@fake_mailer)
-    allow(RegistrationMailer).to receive(:aba_admin_registration_notification).and_return(@fake_mailer)
     allow(PaidClassSessionsCreateJob).to receive(:execute)
   end
 
@@ -45,8 +43,6 @@ describe RegistrationChargeCapturer do
 
       expect(charge.registration.status).to eq 'paid'
       expect(PaidClassSessionsCreateJob).to have_received(:execute).with(charge.registration)
-      expect(RegistrationMailer).to have_received(:registration_with_fees_paid_confirmation).with(registration_1)
-      expect(RegistrationMailer).to have_received(:aba_admin_registration_notification).with(registration_1)
     end
   end
 end

--- a/spec/classes/registration_creator_spec.rb
+++ b/spec/classes/registration_creator_spec.rb
@@ -54,7 +54,9 @@ describe RegistrationCreator do
       expect(registration.primary_family_member).to eq family_member1
       expect(registration.accept_release_form).to be_truthy
       expect(registration.klass).to eq class1
-      expect(registration.total_due).to eq 4000
+      expect(registration.subtotal).to eq 4000
+      expect(registration.handling_fee).to eq 180
+      expect(registration.total_due).to eq 4180
     end
 
     it 'blocks same family member registering the same course for more than once' do
@@ -75,7 +77,9 @@ describe RegistrationCreator do
       expect(registration.primary_family_member).to eq family_member1
       expect(registration.secondary_family_member_id).to eq family_member3.id
       expect(registration.klass).to eq class1
-      expect(registration.total_due).to eq 6000
+      expect(registration.subtotal).to eq 6000
+      expect(registration.total_due).to eq 6270
+      expect(registration.handling_fee).to eq 270
     end
   end
 end

--- a/spec/classes/registration_creator_spec.rb
+++ b/spec/classes/registration_creator_spec.rb
@@ -19,8 +19,6 @@ describe RegistrationCreator do
   describe '.create!' do
     before do
       @fake_mailer = double('fake_mailer', deliver_now: nil)
-      allow(RegistrationMailer).to receive(:registration_confirmation).and_return(@fake_mailer)
-      allow(RegistrationMailer).to receive(:aba_admin_registration_notification).and_return(@fake_mailer)
     end
 
     context 'when no first family members is missing' do
@@ -57,15 +55,11 @@ describe RegistrationCreator do
       expect(registration.accept_release_form).to be_truthy
       expect(registration.klass).to eq class1
       expect(registration.total_due).to eq 4000
-      expect(RegistrationMailer).to have_received(:registration_confirmation).with(registration)
-      expect(RegistrationMailer).to have_received(:aba_admin_registration_notification).with(registration)
     end
 
     it 'blocks same family member registering the same course for more than once' do
       described_class.create!(user, class1.id, false, family_member1)
       registration = Registration.last
-      expect(RegistrationMailer).to have_received(:registration_confirmation).with(registration)
-      expect(RegistrationMailer).to have_received(:aba_admin_registration_notification).with(registration)
       expect do
         described_class.create!(user, class1.id, false, family_member1)
       end.to raise_error(described_class::CreationError, /same class more than once/)
@@ -82,8 +76,6 @@ describe RegistrationCreator do
       expect(registration.secondary_family_member_id).to eq family_member3.id
       expect(registration.klass).to eq class1
       expect(registration.total_due).to eq 6000
-      expect(RegistrationMailer).to have_received(:registration_confirmation).with(registration)
-      expect(RegistrationMailer).to have_received(:aba_admin_registration_notification).with(registration)
     end
   end
 end

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -50,8 +50,8 @@ describe Api::V1::RegistrationsController, type: :request do
       body = JSON.parse(response.body).with_indifferent_access
 
       expect(body[:amount_specification][:course_subtotal]).to eq 6000
-      expect(body[:amount_specification][:handling_fee]).to eq 0
-      expect(body[:amount_specification][:total]).to eq 6000
+      expect(body[:amount_specification][:handling_fee]).to eq 270
+      expect(body[:amount_specification][:total]).to eq 6270
     end
   end
 
@@ -213,7 +213,9 @@ describe Api::V1::RegistrationsController, type: :request do
       expect(body[:registration][:course][:id]).to eq params[:registration][:course_id]
       expect(body[:registration][:primary_family_member_id]).to eq family_member1.id
       expect(body[:registration][:secondary_family_member_id]).to eq family_member3.id
-      expect(body[:registration][:total_due]).to eq 6000
+      expect(body[:registration][:total_due]).to eq 6270
+      expect(body[:registration][:handling_fee]).to eq 270
+      expect(body[:registration][:subtotal]).to eq 6000
       expect(body[:registration][:accept_release_form]).to be_truthy
       registration = Registration.last
       expect(RegistrationMailer).to have_received(:registration_confirmation).with(registration)


### PR DESCRIPTION
notes: Add in the ability to have the new registration endpoint, be able to bypass direct payment (credit card/paypal [in the future]), so that the registration goes through and still asks for payment within certain deadline days.

12/17/2020: Also reworked the handling fee logic to use a flat 4.5% multiple by subtotal