### PR TITLE
[JJ] Ensure to capture same day as the class day registration cost

### DIFF
--- a/app/models/klass.rb
+++ b/app/models/klass.rb
@@ -76,7 +76,7 @@ class Klass < ApplicationRecord
 
   def remaining_session_dates_from_reference_date(referencce_date)
     expected_session_dates.find_all do |date|
-      date >= referencce_date
+      date >= referencce_date.to_date
     end
   end
 

--- a/spec/classes/registration_creator_spec.rb
+++ b/spec/classes/registration_creator_spec.rb
@@ -54,9 +54,9 @@ describe RegistrationCreator do
       expect(registration.primary_family_member).to eq family_member1
       expect(registration.accept_release_form).to be_truthy
       expect(registration.klass).to eq class1
-      expect(registration.subtotal).to eq 4000
-      expect(registration.handling_fee).to eq 180
-      expect(registration.total_due).to eq 4180
+      expect(registration.subtotal).to eq 6000
+      expect(registration.handling_fee).to eq 270
+      expect(registration.total_due).to eq 6270
     end
 
     it 'blocks same family member registering the same course for more than once' do
@@ -77,9 +77,9 @@ describe RegistrationCreator do
       expect(registration.primary_family_member).to eq family_member1
       expect(registration.secondary_family_member_id).to eq family_member3.id
       expect(registration.klass).to eq class1
-      expect(registration.subtotal).to eq 6000
-      expect(registration.total_due).to eq 6270
-      expect(registration.handling_fee).to eq 270
+      expect(registration.subtotal).to eq 9000
+      expect(registration.total_due).to eq 9405
+      expect(registration.handling_fee).to eq 405
     end
   end
 end

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -49,9 +49,9 @@ describe Api::V1::RegistrationsController, type: :request do
       expect(response.status).to eq 200
       body = JSON.parse(response.body).with_indifferent_access
 
-      expect(body[:amount_specification][:course_subtotal]).to eq 6000
-      expect(body[:amount_specification][:handling_fee]).to eq 270
-      expect(body[:amount_specification][:total]).to eq 6270
+      expect(body[:amount_specification][:course_subtotal]).to eq 9000
+      expect(body[:amount_specification][:handling_fee]).to eq 405
+      expect(body[:amount_specification][:total]).to eq 9405
     end
   end
 
@@ -213,9 +213,9 @@ describe Api::V1::RegistrationsController, type: :request do
       expect(body[:registration][:course][:id]).to eq params[:registration][:course_id]
       expect(body[:registration][:primary_family_member_id]).to eq family_member1.id
       expect(body[:registration][:secondary_family_member_id]).to eq family_member3.id
-      expect(body[:registration][:total_due]).to eq 6270
-      expect(body[:registration][:handling_fee]).to eq 270
-      expect(body[:registration][:subtotal]).to eq 6000
+      expect(body[:registration][:total_due]).to eq 9405
+      expect(body[:registration][:handling_fee]).to eq 405
+      expect(body[:registration][:subtotal]).to eq 9000
       expect(body[:registration][:accept_release_form]).to be_truthy
       registration = Registration.last
       expect(RegistrationMailer).to have_received(:registration_confirmation).with(registration)


### PR DESCRIPTION
notes: Ensure to capture same day as the class day registration cost

This is to fix the problem, of someone who registers for the kid, on the same day, of a class that will occur. If so, we will also charge for this day.